### PR TITLE
Enable metrics on manager

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,8 +3,8 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/Dragonfly2/main/docs/images/logo/dragonfly.svg
 type: application
-version: 0.7.6
-appVersion: 0.7.6
+version: 0.7.7
+appVersion: 0.7.7
 keywords:
   - dragonfly
   - d7y
@@ -26,8 +26,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Compatible with v2.0.3 redis addresses configuration
-    - Update dragonfly image tag to v2.0.7-alpha.3
+    - Fix manager metrics enable configuration
 
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/dragonfly/templates/manager/manager-configmap.yaml
+++ b/charts/dragonfly/templates/manager/manager-configmap.yaml
@@ -57,6 +57,7 @@ data:
 {{ toYaml .Values.manager.config.security | indent 6 }}
     {{- if .Values.manager.metrics.enable }}
     metrics:
+      enable: true
       addr: ":8000"
     {{- end }}
     console: {{ .Values.manager.config.console }}

--- a/charts/dragonfly/templates/manager/manager-configmap.yaml
+++ b/charts/dragonfly/templates/manager/manager-configmap.yaml
@@ -55,11 +55,9 @@ data:
 {{ toYaml .Values.manager.config.objectStorage | indent 6 }}
     security:
 {{ toYaml .Values.manager.config.security | indent 6 }}
-    {{- if .Values.manager.metrics.enable }}
     metrics:
-      enable: true
+      enable: {{ .Values.manager.metrics.enable }}
       addr: ":8000"
-    {{- end }}
     console: {{ .Values.manager.config.console }}
     verbose: {{ .Values.manager.config.verbose }}
     {{- if .Values.manager.config.verbose }}


### PR DESCRIPTION
Enable metrics on manager when `Values.manager.metrics.enable` is `true`
There was a missing config field to really enable metrics: `enable: true`