### PR TITLE
add chart for nydus-snapshotter

### DIFF
--- a/charts/nydus-snapshotter/.helmignore
+++ b/charts/nydus-snapshotter/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# Helm Docs
+README.md.gotmpl

--- a/charts/nydus-snapshotter/Chart.yaml
+++ b/charts/nydus-snapshotter/Chart.yaml
@@ -1,0 +1,40 @@
+apiVersion: v2
+name: nydus-snapshotter
+description: Nydus snapshotter is an external plugin of containerd for Nydus image service which implements a chunk-based content-addressable filesystem on top of a called RAFS.
+icon: https://github.com/dragonflyoss/image-service/raw/master/misc/logo.svg
+type: application
+version: 0.0.1
+appVersion: 0.0.1
+keywords:
+  - nydus
+  - nydus-snapshotter
+  - dragonfly
+  - d7y
+  - P2P
+  - image
+
+maintainers:
+  - name: jim3ma
+    email: majinjing3@gmail.com
+  - name: gaius-qi
+    email: gaius.qi@gmail.com
+  - name: liubin
+    email: liubin0329@gmail.com
+
+home: https://nydus.dev/
+
+sources:
+  - https://github.com/dragonflyoss/image-service
+  - https://github.com/containerd/nydus-snapshotter/
+
+annotations:
+  artifacthub.io/changes: |
+    - Firs release of nydus-snapshotter
+  artifacthub.io/links: |
+    - name: Chart Source
+      url: https://github.com/dragonflyoss/helm-charts
+    - name: Source
+      url: https://github.com/containerd/nydus-snapshotter
+  artifacthub.io/images: |
+    - name: nydus-snapshotter
+      image: ghcr.io/nydus-snapshotter/nydus-snapshotter:latest

--- a/charts/nydus-snapshotter/Chart.yaml
+++ b/charts/nydus-snapshotter/Chart.yaml
@@ -29,7 +29,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Firs release of nydus-snapshotter
+    - First release of nydus-snapshotter
   artifacthub.io/links: |
     - name: Chart Source
       url: https://github.com/dragonflyoss/helm-charts

--- a/charts/nydus-snapshotter/README.md
+++ b/charts/nydus-snapshotter/README.md
@@ -1,0 +1,92 @@
+# Nydus-snapshotter Helm Chart
+
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/dragonfly)](https://artifacthub.io/packages/search?repo=dragonfly)
+
+## TL;DR
+
+```shell
+helm repo add dragonfly https://dragonflyoss.github.io/helm-charts/
+helm install --create-namespace --namespace nydus-snapshotter nydus-snapshotter dragonfly/nydus-snapshotter
+```
+
+## Introduction
+
+Nydus snapshotter is an external plugin of containerd for [Nydus image service](https://nydus.dev) which implements a chunk-based content-addressable filesystem on top of a called `RAFS (Registry Acceleration File System)` format that improves the current OCI image specification, in terms of container launching speed, image space, and network bandwidth efficiency, as well as data integrity with several runtime backends: FUSE, virtiofs and in-kernel [EROFS](https://www.kernel.org/doc/html/latest/filesystems/erofs.html).
+
+Nydus supports lazy pulling feature since pulling image is one of the time-consuming steps in the container lifecycle. Lazy pulling here means a container can run even the image is partially available and necessary chunks of the image are fetched on-demand. Apart from that, Nydus also supports [(e)Stargz](https://github.com/containerd/stargz-snapshotter) lazy pulling directly **WITHOUT** any explicit conversion.
+
+For more details about how to build Nydus container image, please refer to [nydusify](https://github.com/dragonflyoss/image-service/blob/master/docs/nydusify.md) conversion tool and [acceld](https://github.com/goharbor/acceleration-service).
+
+## Prerequisites
+
+- Kubernetes cluster 1.20+
+- Helm v3.8.0+
+
+## Installation Guide
+
+For more detail about installation is available in [nydus-snapshotter repo](https://github.com/containerd/nydus-snapshotter).
+
+## Installation
+
+### Install with custom configuration
+
+Create the `values.yaml` configuration file.
+
+```yaml
+nydusSnapshotter:
+  name: nydus-snapshotter
+  image: ghcr.io/containerd/nydus-snapshotter
+  tag: v1.2.11
+```
+Install nydus-snapshotter chart with release name `nydus-snapshotter`:
+
+```shell
+helm repo add dragonfly https://dragonflyoss.github.io/helm-charts/
+helm install --create-namespace --namespace nydus-snapshotter nydus-snapshotter dragonfly/nydus-snapshotter -f values.yaml
+```
+
+## Uninstall
+
+Uninstall the `nydus-snapshotter` daemonset:
+
+```shell
+helm delete nydus-snapshotter --namespace nydus-snapshotter
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| containerRuntime | object | `{"containerd":{"configFile":"/etc/containerd/config.toml","enable":true},"initContainerImage":"library/alpine:latest"}` | [Experimental] Container runtime support Choose special container runtime in Kubernetes. Support: Containerd, Docker, CRI-O |
+| containerRuntime.containerd | object | `{"configFile":"/etc/containerd/config.toml","enable":true}` | [Experimental] Containerd support |
+| containerRuntime.containerd.configFile | string | `"/etc/containerd/config.toml"` | Custom config path directory, default is /etc/containerd/config.toml |
+| containerRuntime.containerd.enable | bool | `true` | Enable containerd support Inject nydus-snapshotter config into ${containerRuntime.containerd.configFile}, |
+| containerRuntime.initContainerImage | string | `"library/alpine:latest"` | The image name of init container, just to update container runtime configuration file |
+| dragonfly.enable | bool | `true` | Enable dragonfly |
+| dragonfly.mirrorConfig.auth_through | bool | `false` |  |
+| dragonfly.mirrorConfig.headers.X-Dragonfly-Registry | string | `"https://index.docker.io"` |  |
+| dragonfly.mirrorConfig.host | string | `"http://127.0.0.1:65001"` |  |
+| dragonfly.mirrorConfig.ping_url | string | `"http://127.0.0.1:40901/server/ping"` |  |
+| fullnameOverride | string | `""` | Override nydus-snapshotter fullname |
+| nameOverride | string | `""` | Override nydus-snapshotter name |
+| nydusSnapshotter.daemonsetAnnotations | object | `{}` | Daemonset annotations |
+| nydusSnapshotter.fullnameOverride | string | `""` | Override nydus-snapshotter fullname |
+| nydusSnapshotter.hostAliases | list | `[]` | Host Aliases |
+| nydusSnapshotter.hostNetwork | bool | `true` | Let nydus-snapshotter run in host network |
+| nydusSnapshotter.image | string | `"ghcr.io/containerd/nydus-snapshotter"` | Image repository |
+| nydusSnapshotter.name | string | `"nydus-snapshotter"` | nydus-snapshotter name |
+| nydusSnapshotter.nameOverride | string | `""` | Override nydus-snapshotter name |
+| nydusSnapshotter.nodeSelector | object | `{}` | Node labels for pod assignment |
+| nydusSnapshotter.podAnnotations | object | `{}` | Pod annotations |
+| nydusSnapshotter.podLabels | object | `{}` | Pod labels |
+| nydusSnapshotter.priorityClassName | string | `""` | Pod priorityClassName |
+| nydusSnapshotter.pullPolicy | string | `"Always"` | Image pull policy |
+| nydusSnapshotter.resources | object | `{"limits":{"cpu":"2","memory":"2Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits |
+| nydusSnapshotter.tag | string | `"v1.2.11"` | Image tag (FIXME: This version should be updated after a new snapshotter is released.) |
+| nydusSnapshotter.terminationGracePeriodSeconds | string | `nil` | Pod terminationGracePeriodSeconds |
+| nydusSnapshotter.tolerations | list | `[]` | List of node taints to tolerate |
+
+## Chart dependencies
+
+| Repository | Name | Version |
+|------------|------|---------|

--- a/charts/nydus-snapshotter/README.md
+++ b/charts/nydus-snapshotter/README.md
@@ -57,34 +57,30 @@ helm delete nydus-snapshotter --namespace nydus-snapshotter
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| containerRuntime | object | `{"containerd":{"configFile":"/etc/containerd/config.toml","enable":true},"initContainerImage":"ghcr.io/liubin/toml-cli:latest"}` | [Experimental] Container runtime support Choose special container runtime in Kubernetes. Support: Containerd, Docker, CRI-O |
+| containerRuntime | object | `{"containerd":{"configFile":"/etc/containerd/config.toml","enable":true},"initContainerImage":"ghcr.io/liubin/toml-cli:v0.0.7"}` | [Experimental] Container runtime support Choose special container runtime in Kubernetes. Support: Containerd, Docker, CRI-O |
 | containerRuntime.containerd | object | `{"configFile":"/etc/containerd/config.toml","enable":true}` | [Experimental] Containerd support |
 | containerRuntime.containerd.configFile | string | `"/etc/containerd/config.toml"` | Custom config path directory, default is /etc/containerd/config.toml |
 | containerRuntime.containerd.enable | bool | `true` | Enable containerd support Inject nydus-snapshotter config into ${containerRuntime.containerd.configFile}, |
-| containerRuntime.initContainerImage | string | `"ghcr.io/liubin/toml-cli:latest"` | The image name of init container, just to update container runtime configuration file |
+| containerRuntime.initContainerImage | string | `"ghcr.io/liubin/toml-cli:v0.0.7"` | The image name of init container, just to update container runtime configuration file |
+| daemonsetAnnotations | object | `{}` | Daemonset annotations |
 | dragonfly.enable | bool | `true` | Enable dragonfly |
 | dragonfly.mirrorConfig.auth_through | bool | `false` |  |
 | dragonfly.mirrorConfig.headers.X-Dragonfly-Registry | string | `"https://index.docker.io"` |  |
 | dragonfly.mirrorConfig.host | string | `"http://127.0.0.1:65001"` |  |
 | dragonfly.mirrorConfig.ping_url | string | `"http://127.0.0.1:40901/server/ping"` |  |
-| fullnameOverride | string | `""` | Override nydus-snapshotter fullname |
-| nameOverride | string | `""` | Override nydus-snapshotter name |
-| nydusSnapshotter.daemonsetAnnotations | object | `{}` | Daemonset annotations |
-| nydusSnapshotter.fullnameOverride | string | `""` | Override nydus-snapshotter fullname |
-| nydusSnapshotter.hostAliases | list | `[]` | Host Aliases |
-| nydusSnapshotter.hostNetwork | bool | `true` | Let nydus-snapshotter run in host network |
-| nydusSnapshotter.image | string | `"ghcr.io/containerd/nydus-snapshotter"` | Image repository |
-| nydusSnapshotter.name | string | `"nydus-snapshotter"` | nydus-snapshotter name |
-| nydusSnapshotter.nameOverride | string | `""` | Override nydus-snapshotter name |
-| nydusSnapshotter.nodeSelector | object | `{}` | Node labels for pod assignment |
-| nydusSnapshotter.podAnnotations | object | `{}` | Pod annotations |
-| nydusSnapshotter.podLabels | object | `{}` | Pod labels |
-| nydusSnapshotter.priorityClassName | string | `""` | Pod priorityClassName |
-| nydusSnapshotter.pullPolicy | string | `"Always"` | Image pull policy |
-| nydusSnapshotter.resources | object | `{"limits":{"cpu":"2","memory":"2Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits |
-| nydusSnapshotter.tag | string | `"v1.2.11"` | Image tag (FIXME: This version should be updated after a new snapshotter is released.) |
-| nydusSnapshotter.terminationGracePeriodSeconds | string | `nil` | Pod terminationGracePeriodSeconds |
-| nydusSnapshotter.tolerations | list | `[]` | List of node taints to tolerate |
+| hostAliases | list | `[]` | Host Aliases |
+| hostNetwork | bool | `true` | Let nydus-snapshotter run in host network |
+| image | string | `"ghcr.io/containerd/nydus-snapshotter"` | Image repository |
+| name | string | `"nydus-snapshotter"` | nydus-snapshotter name |
+| nodeSelector | object | `{}` | Node labels for pod assignment |
+| podAnnotations | object | `{}` | Pod annotations |
+| podLabels | object | `{}` | Pod labels |
+| priorityClassName | string | `""` | Pod priorityClassName |
+| pullPolicy | string | `"Always"` | Image pull policy |
+| resources | object | `{"limits":{"cpu":"2","memory":"2Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits |
+| tag | string | `"v0.4.0"` | Image tag |
+| terminationGracePeriodSeconds | string | `nil` | Pod terminationGracePeriodSeconds |
+| tolerations | list | `[]` | List of node taints to tolerate |
 
 ## Chart dependencies
 

--- a/charts/nydus-snapshotter/README.md
+++ b/charts/nydus-snapshotter/README.md
@@ -57,11 +57,11 @@ helm delete nydus-snapshotter --namespace nydus-snapshotter
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| containerRuntime | object | `{"containerd":{"configFile":"/etc/containerd/config.toml","enable":true},"initContainerImage":"library/alpine:latest"}` | [Experimental] Container runtime support Choose special container runtime in Kubernetes. Support: Containerd, Docker, CRI-O |
+| containerRuntime | object | `{"containerd":{"configFile":"/etc/containerd/config.toml","enable":true},"initContainerImage":"ghcr.io/liubin/toml-cli:latest"}` | [Experimental] Container runtime support Choose special container runtime in Kubernetes. Support: Containerd, Docker, CRI-O |
 | containerRuntime.containerd | object | `{"configFile":"/etc/containerd/config.toml","enable":true}` | [Experimental] Containerd support |
 | containerRuntime.containerd.configFile | string | `"/etc/containerd/config.toml"` | Custom config path directory, default is /etc/containerd/config.toml |
 | containerRuntime.containerd.enable | bool | `true` | Enable containerd support Inject nydus-snapshotter config into ${containerRuntime.containerd.configFile}, |
-| containerRuntime.initContainerImage | string | `"library/alpine:latest"` | The image name of init container, just to update container runtime configuration file |
+| containerRuntime.initContainerImage | string | `"ghcr.io/liubin/toml-cli:latest"` | The image name of init container, just to update container runtime configuration file |
 | dragonfly.enable | bool | `true` | Enable dragonfly |
 | dragonfly.mirrorConfig.auth_through | bool | `false` |  |
 | dragonfly.mirrorConfig.headers.X-Dragonfly-Registry | string | `"https://index.docker.io"` |  |

--- a/charts/nydus-snapshotter/README.md.gotmpl
+++ b/charts/nydus-snapshotter/README.md.gotmpl
@@ -1,0 +1,61 @@
+# Nydus-snapshotter Helm Chart
+
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/dragonfly)](https://artifacthub.io/packages/search?repo=dragonfly)
+
+
+## TL;DR
+
+```shell
+helm repo add dragonfly https://dragonflyoss.github.io/helm-charts/
+helm install --create-namespace --namespace nydus-snapshotter nydus-snapshotter dragonfly/nydus-snapshotter
+```
+
+## Introduction
+
+Nydus snapshotter is an external plugin of containerd for [Nydus image service](https://nydus.dev) which implements a chunk-based content-addressable filesystem on top of a called `RAFS (Registry Acceleration File System)` format that improves the current OCI image specification, in terms of container launching speed, image space, and network bandwidth efficiency, as well as data integrity with several runtime backends: FUSE, virtiofs and in-kernel [EROFS](https://www.kernel.org/doc/html/latest/filesystems/erofs.html).
+
+Nydus supports lazy pulling feature since pulling image is one of the time-consuming steps in the container lifecycle. Lazy pulling here means a container can run even the image is partially available and necessary chunks of the image are fetched on-demand. Apart from that, Nydus also supports [(e)Stargz](https://github.com/containerd/stargz-snapshotter) lazy pulling directly **WITHOUT** any explicit conversion.
+
+For more details about how to build Nydus container image, please refer to [nydusify](https://github.com/dragonflyoss/image-service/blob/master/docs/nydusify.md) conversion tool and [acceld](https://github.com/goharbor/acceleration-service).
+
+## Prerequisites
+
+- Kubernetes cluster 1.20+
+- Helm v3.8.0+
+
+## Installation Guide
+
+For more detail about installation is available in [nydus-snapshotter repo](https://github.com/containerd/nydus-snapshotter).
+
+## Installation
+
+### Install with custom configuration
+
+Create the `values.yaml` configuration file.
+
+```yaml
+nydusSnapshotter:
+  name: nydus-snapshotter
+  image: ghcr.io/containerd/nydus-snapshotter
+  tag: v1.2.11
+```
+Install nydus-snapshotter chart with release name `nydus-snapshotter`:
+
+```shell
+helm repo add dragonfly https://dragonflyoss.github.io/helm-charts/
+helm install --create-namespace --namespace nydus-snapshotter nydus-snapshotter dragonfly/nydus-snapshotter -f values.yaml
+```
+
+## Uninstall
+
+Uninstall the `nydus-snapshotter` daemonset:
+
+```shell
+helm delete nydus-snapshotter --namespace nydus-snapshotter
+```
+
+{{ template "chart.valuesSection" . }}
+
+## Chart dependencies
+
+{{ template "chart.requirementsTable" . }}

--- a/charts/nydus-snapshotter/templates/NOTES.txt
+++ b/charts/nydus-snapshotter/templates/NOTES.txt
@@ -1,0 +1,8 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }}

--- a/charts/nydus-snapshotter/templates/_helpers.tpl
+++ b/charts/nydus-snapshotter/templates/_helpers.tpl
@@ -1,0 +1,24 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nydus-snapshotter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "nydus-snapshotter.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/nydus-snapshotter/templates/_helpers.tpl
+++ b/charts/nydus-snapshotter/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "nydus-snapshotter.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- default .Chart.Name -}}
 {{- end -}}
 
 {{/*
@@ -11,14 +11,10 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "nydus-snapshotter.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- $name := default .Chart.Name -}}
 {{- if contains $name .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/nydus-snapshotter/templates/nydus-snapshotter/snapshotter-configmap.yaml
+++ b/charts/nydus-snapshotter/templates/nydus-snapshotter/snapshotter-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    component: {{ .Values.nydusSnapshotter.name }}
+    component: {{ .Values.name }}
 data:
   config.json: |-
     {

--- a/charts/nydus-snapshotter/templates/nydus-snapshotter/snapshotter-configmap.yaml
+++ b/charts/nydus-snapshotter/templates/nydus-snapshotter/snapshotter-configmap.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "nydus-snapshotter.fullname" . }}
+  labels:
+    app: {{ template "nydus-snapshotter.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ .Values.nydusSnapshotter.name }}
+data:
+  config.json: |-
+    {
+      "device": {
+        "backend": {
+          "type": "registry",
+          "config": {
+          {{- if .Values.dragonfly.enable }}
+            "mirrors": [
+              {{ mustToJson .Values.dragonfly.mirrorConfig | indent 8 }}
+            ],
+          {{- end }}
+            "scheme": "https",
+            "skip_verify": false,
+            "timeout": 10,
+            "connect_timeout": 10,
+            "retry_limit": 2
+          }
+        },
+        "cache": {
+          "type": "blobcache",
+          "config": {
+            "work_dir": "/var/lib/nydus/cache/"
+          }
+        }
+      },
+      "mode": "direct",
+      "digest_validate": false,
+      "iostats_files": false,
+      "enable_xattr": true,
+      "fs_prefetch": {
+        "enable": true,
+        "threads_count": 10,
+        "merging_size": 131072,
+        "bandwidth_rate": 1048576
+      }
+    }

--- a/charts/nydus-snapshotter/templates/nydus-snapshotter/snapshotter-daemonset.yaml
+++ b/charts/nydus-snapshotter/templates/nydus-snapshotter/snapshotter-daemonset.yaml
@@ -37,6 +37,7 @@ spec:
 {{ toYaml .Values.nydusSnapshotter.nodeSelector | indent 8 }}
       {{- end }}
       hostNetwork: {{ .Values.nydusSnapshotter.hostNetwork }}
+      hostPID: {{ .Values.containerRuntime.containerd.enable }}
       {{- if .Values.nydusSnapshotter.hostNetwork }}
       dnsPolicy: "ClusterFirstWithHostNet"
       {{- end }}
@@ -93,31 +94,29 @@ spec:
         - |-
           etcContainerd={{ .Values.containerRuntime.containerd.configFile }}
 
-          if grep -q "nydus" $etcContainerd; then
+          toml check $etcContainerd proxy_plugins.nydus
+          if [ $? -eq 0 ]; then
             echo "nydus snapshotter has already configured."
             exit 0
           fi
 
-          # FIXME use https://github.com/gnprice/toml-cli to edit toml file
+          toml set --overwrite $etcContainerd plugins.\"io.containerd.grpc.v1.cri\".containerd.discard_unpacked_layers false
+          toml set --overwrite $etcContainerd plugins.\"io.containerd.grpc.v1.cri\".containerd.disable_snapshot_annotations false
+          toml set --overwrite $etcContainerd plugins.\"io.containerd.grpc.v1.cri\".containerd.snapshotter nydus
+
+          # toml command not support to set block, so just use cat command.
           cat << EOF >> $etcContainerd
           [proxy_plugins]
             [proxy_plugins.nydus]
               type = "snapshot"
               address = "/run/containerd-nydus/containerd-nydus-grpc.sock"
-
-          [plugins."io.containerd.grpc.v1.cri".containerd]
-            # snapshotter = "nydus"
-            disable_snapshot_annotations = false
-
-          # this is a workaround to not change the system default snapshotter
-          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc-nydus]
-            runtime_type = "io.containerd.runc.v2"
-            snapshotter = "nydus"
           EOF
 
           # currently, without host pid in container, we can not nsenter with pid and can not invoke systemctl correctly.
-          nsenter -t 1 -m systemctl -- restart containerd.service
-
+          # FIXME: can't restart, because global snapshotter has been set to nydus, but it is not started yet.
+          # nsenter -t 1 -m systemctl -- restart containerd.service
+        securityContext:
+          privileged: true
         volumeMounts:
         - name: containerd-conf
           mountPath: {{ .Values.containerRuntime.containerd.configFile }}

--- a/charts/nydus-snapshotter/templates/nydus-snapshotter/snapshotter-daemonset.yaml
+++ b/charts/nydus-snapshotter/templates/nydus-snapshotter/snapshotter-daemonset.yaml
@@ -65,7 +65,15 @@ spec:
           value: "false"
         resources:
 {{ toYaml .Values.nydusSnapshotter.resources | indent 12 }}
-
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - "/bin/sh"
+              - "-c"
+              - |
+                # currently, without host pid in container, we can not nsenter with pid and can not invoke systemctl correctly.
+                nsenter -t 1 -m systemctl -- restart containerd.service
         volumeMounts:
         - name: config
           mountPath: "/etc/nydus/"
@@ -112,11 +120,6 @@ spec:
               address = "/run/containerd-nydus/containerd-nydus-grpc.sock"
           EOF
 
-          # currently, without host pid in container, we can not nsenter with pid and can not invoke systemctl correctly.
-          # FIXME: can't restart, because global snapshotter has been set to nydus, but it is not started yet.
-          # nsenter -t 1 -m systemctl -- restart containerd.service
-        securityContext:
-          privileged: true
         volumeMounts:
         - name: containerd-conf
           mountPath: {{ .Values.containerRuntime.containerd.configFile }}

--- a/charts/nydus-snapshotter/templates/nydus-snapshotter/snapshotter-daemonset.yaml
+++ b/charts/nydus-snapshotter/templates/nydus-snapshotter/snapshotter-daemonset.yaml
@@ -1,0 +1,145 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "nydus-snapshotter.fullname" . }}
+  labels:
+    app: {{ template "nydus-snapshotter.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: "{{ .Values.nydusSnapshotter.name }}"
+  annotations:
+    {{- if .Values.nydusSnapshotter.daemonsetAnnotations }}
+{{ toYaml .Values.nydusSnapshotter.daemonsetAnnotations | indent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "nydus-snapshotter.fullname" . }}
+      component: "{{ .Values.nydusSnapshotter.name }}"
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "nydus-snapshotter.fullname" . }}
+        component: "{{ .Values.nydusSnapshotter.name }}"
+        release: {{ .Release.Name }}
+        {{- if .Values.nydusSnapshotter.podLabels }}
+{{ toYaml .Values.nydusSnapshotter.podLabels | indent 8 }}
+        {{- end }}
+      {{- if .Values.nydusSnapshotter.podAnnotations }}
+      annotations:
+{{ toYaml .Values.nydusSnapshotter.podAnnotations | indent 8 }}
+      {{- end }}
+    spec:
+      {{- if .Values.nydusSnapshotter.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nydusSnapshotter.nodeSelector | indent 8 }}
+      {{- end }}
+      hostNetwork: {{ .Values.nydusSnapshotter.hostNetwork }}
+      {{- if .Values.nydusSnapshotter.hostNetwork }}
+      dnsPolicy: "ClusterFirstWithHostNet"
+      {{- end }}
+      {{- if .Values.nydusSnapshotter.tolerations }}
+      tolerations:
+{{ toYaml .Values.nydusSnapshotter.tolerations | indent 8 }}
+      {{- end }}
+
+      {{- if quote .Values.nydusSnapshotter.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.nydusSnapshotter.terminationGracePeriodSeconds }}
+      {{- end }}
+      {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.nydusSnapshotter.priorityClassName) }}
+      priorityClassName: {{ .Values.nydusSnapshotter.priorityClassName }}
+      {{- end }}
+      {{- if .Values.nydusSnapshotter.hostAliases }}
+      hostAliases:
+{{ toYaml .Values.nydusSnapshotter.hostAliases | indent 8 }}
+      {{- end }}
+      containers:
+      - name: nydus-snapshotter
+        image: "{{ .Values.nydusSnapshotter.image }}:{{ .Values.nydusSnapshotter.tag }}"
+        imagePullPolicy: {{ .Values.nydusSnapshotter.pullPolicy | quote }}
+        env:
+        - name: ENABLE_NYDUS_OVERLAY
+          value: "false"
+        resources:
+{{ toYaml .Values.nydusSnapshotter.resources | indent 12 }}
+
+        volumeMounts:
+        - name: config
+          mountPath: "/etc/nydus/"
+        - name: nydus-lib
+          mountPath: "/var/lib/containerd-nydus"
+          mountPropagation: Bidirectional
+        - name: nydus-run
+          mountPath: "/run/containerd-nydus"
+          mountPropagation: Bidirectional
+        - name: fuse
+          mountPath: "/dev/fuse"
+
+        securityContext:
+          privileged: true
+
+      initContainers:
+      {{- if .Values.containerRuntime.containerd.enable }}
+      - name: update-containerd
+        image: "{{ .Values.containerRuntime.initContainerImage }}"
+        imagePullPolicy: {{ .Values.nydusSnapshotter.pullPolicy | quote }}
+        resources:
+{{ toYaml .Values.nydusSnapshotter.resources | indent 12 }}
+        command:
+        - /bin/sh
+        - -cx
+        - |-
+          etcContainerd={{ .Values.containerRuntime.containerd.configFile }}
+
+          if grep -q "nydus" $etcContainerd; then
+            echo "nydus snapshotter has already configured."
+            exit 0
+          fi
+
+          # FIXME use https://github.com/gnprice/toml-cli to edit toml file
+          cat << EOF >> $etcContainerd
+          [proxy_plugins]
+            [proxy_plugins.nydus]
+              type = "snapshot"
+              address = "/run/containerd-nydus/containerd-nydus-grpc.sock"
+
+          [plugins."io.containerd.grpc.v1.cri".containerd]
+            # snapshotter = "nydus"
+            disable_snapshot_annotations = false
+
+          # this is a workaround to not change the system default snapshotter
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc-nydus]
+            runtime_type = "io.containerd.runc.v2"
+            snapshotter = "nydus"
+          EOF
+
+          # currently, without host pid in container, we can not nsenter with pid and can not invoke systemctl correctly.
+          nsenter -t 1 -m systemctl -- restart containerd.service
+
+        volumeMounts:
+        - name: containerd-conf
+          mountPath: {{ .Values.containerRuntime.containerd.configFile }}
+      {{- end }}
+
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "nydus-snapshotter.fullname" . }}
+      - name: nydus-run
+        hostPath:
+          path: /run/containerd-nydus
+          type: DirectoryOrCreate
+      - name: nydus-lib
+        hostPath:
+          path: /var/lib/containerd-nydus
+          type: DirectoryOrCreate
+      - name: fuse
+        hostPath:
+          path: /dev/fuse
+      {{- if .Values.containerRuntime.containerd.enable }}
+      - name: containerd-conf
+        hostPath:
+          path: {{ .Values.containerRuntime.containerd.configFile }}
+      {{- end }}

--- a/charts/nydus-snapshotter/templates/nydus-snapshotter/snapshotter-daemonset.yaml
+++ b/charts/nydus-snapshotter/templates/nydus-snapshotter/snapshotter-daemonset.yaml
@@ -7,64 +7,65 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    component: "{{ .Values.nydusSnapshotter.name }}"
+    component: "{{ .Values.name }}"
   annotations:
-    {{- if .Values.nydusSnapshotter.daemonsetAnnotations }}
-{{ toYaml .Values.nydusSnapshotter.daemonsetAnnotations | indent 4 }}
+    {{- if .Values.daemonsetAnnotations }}
+{{ toYaml .Values.daemonsetAnnotations | indent 4 }}
     {{- end }}
 spec:
   selector:
     matchLabels:
       app: {{ template "nydus-snapshotter.fullname" . }}
-      component: "{{ .Values.nydusSnapshotter.name }}"
+      component: "{{ .Values.name }}"
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
         app: {{ template "nydus-snapshotter.fullname" . }}
-        component: "{{ .Values.nydusSnapshotter.name }}"
+        component: "{{ .Values.name }}"
         release: {{ .Release.Name }}
-        {{- if .Values.nydusSnapshotter.podLabels }}
-{{ toYaml .Values.nydusSnapshotter.podLabels | indent 8 }}
+        {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
         {{- end }}
-      {{- if .Values.nydusSnapshotter.podAnnotations }}
+      {{- if .Values.podAnnotations }}
       annotations:
-{{ toYaml .Values.nydusSnapshotter.podAnnotations | indent 8 }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      {{- if .Values.nydusSnapshotter.nodeSelector }}
+      serviceAccountName: {{template "nydus-snapshotter.fullname" . }}-sa
+      {{- if .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nydusSnapshotter.nodeSelector | indent 8 }}
+{{ toYaml .Values.nodeSelector | indent 8 }}
       {{- end }}
-      hostNetwork: {{ .Values.nydusSnapshotter.hostNetwork }}
+      hostNetwork: {{ .Values.hostNetwork }}
       hostPID: {{ .Values.containerRuntime.containerd.enable }}
-      {{- if .Values.nydusSnapshotter.hostNetwork }}
+      {{- if .Values.hostNetwork }}
       dnsPolicy: "ClusterFirstWithHostNet"
       {{- end }}
-      {{- if .Values.nydusSnapshotter.tolerations }}
+      {{- if .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.nydusSnapshotter.tolerations | indent 8 }}
+{{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
 
-      {{- if quote .Values.nydusSnapshotter.terminationGracePeriodSeconds }}
-      terminationGracePeriodSeconds: {{ .Values.nydusSnapshotter.terminationGracePeriodSeconds }}
+      {{- if quote .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}
-      {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.nydusSnapshotter.priorityClassName) }}
-      priorityClassName: {{ .Values.nydusSnapshotter.priorityClassName }}
+      {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.priorityClassName) }}
+      priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
-      {{- if .Values.nydusSnapshotter.hostAliases }}
+      {{- if .Values.hostAliases }}
       hostAliases:
-{{ toYaml .Values.nydusSnapshotter.hostAliases | indent 8 }}
+{{ toYaml .Values.hostAliases | indent 8 }}
       {{- end }}
       containers:
       - name: nydus-snapshotter
-        image: "{{ .Values.nydusSnapshotter.image }}:{{ .Values.nydusSnapshotter.tag }}"
-        imagePullPolicy: {{ .Values.nydusSnapshotter.pullPolicy | quote }}
+        image: "{{ .Values.image }}:{{ .Values.tag }}"
+        imagePullPolicy: {{ .Values.pullPolicy | quote }}
         env:
         - name: ENABLE_NYDUS_OVERLAY
           value: "false"
         resources:
-{{ toYaml .Values.nydusSnapshotter.resources | indent 12 }}
+{{ toYaml .Values.resources | indent 12 }}
         lifecycle:
           postStart:
             exec:
@@ -93,9 +94,9 @@ spec:
       {{- if .Values.containerRuntime.containerd.enable }}
       - name: update-containerd
         image: "{{ .Values.containerRuntime.initContainerImage }}"
-        imagePullPolicy: {{ .Values.nydusSnapshotter.pullPolicy | quote }}
+        imagePullPolicy: {{ .Values.pullPolicy | quote }}
         resources:
-{{ toYaml .Values.nydusSnapshotter.resources | indent 12 }}
+{{ toYaml .Values.resources | indent 12 }}
         command:
         - /bin/sh
         - -cx

--- a/charts/nydus-snapshotter/templates/nydus-snapshotter/snapshotter-rbac.yaml
+++ b/charts/nydus-snapshotter/templates/nydus-snapshotter/snapshotter-rbac.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{template "nydus-snapshotter.fullname" . }}-sa
+  namespace: {{ .Release.Namespace }}
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "nydus-snapshotter.fullname" . }}-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "nydus-snapshotter.fullname" . }}-role-binding
+roleRef:
+  kind: ClusterRole
+  name: {{ template "nydus-snapshotter.fullname" . }}-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ template "nydus-snapshotter.fullname" . }}-sa
+  namespace: {{ .Release.Namespace }}
+

--- a/charts/nydus-snapshotter/values.yaml
+++ b/charts/nydus-snapshotter/values.yaml
@@ -1,49 +1,39 @@
 # nydus-snapshotter Helm Chart Values
 
-# -- Override nydus-snapshotter name
-nameOverride: ""
-# -- Override nydus-snapshotter fullname
-fullnameOverride: ""
-
-nydusSnapshotter:
-  # -- nydus-snapshotter name
-  name: nydus-snapshotter
-  # -- Override nydus-snapshotter name
-  nameOverride: ""
-  # -- Override nydus-snapshotter fullname
-  fullnameOverride: ""
-  # -- Image repository
-  image: ghcr.io/containerd/nydus-snapshotter
-  # -- Image tag (FIXME: This version should be updated after a new snapshotter is released.)
-  tag: v1.2.11
-  # -- Image pull policy
-  pullPolicy: Always
-  # -- Let nydus-snapshotter run in host network
-  hostNetwork: true
-  # -- Host Aliases
-  hostAliases: []
-  # -- Pod resource requests and limits
-  resources:
-    requests:
-      cpu: "0"
-      memory: "0"
-    limits:
-      cpu: "2"
-      memory: "2Gi"
-  # -- Pod priorityClassName
-  priorityClassName: ""
-  # -- Node labels for pod assignment
-  nodeSelector: {}
-  # -- Pod terminationGracePeriodSeconds
-  terminationGracePeriodSeconds:
-  # -- List of node taints to tolerate
-  tolerations: []
-  # -- Pod annotations
-  podAnnotations: {}
-  # -- Pod labels
-  podLabels: {}
-  # -- Daemonset annotations
-  daemonsetAnnotations: {}
+# -- nydus-snapshotter name
+name: nydus-snapshotter
+# -- Image repository
+image: ghcr.io/containerd/nydus-snapshotter
+# -- Image tag
+tag: v0.4.0
+# -- Image pull policy
+pullPolicy: Always
+# -- Let nydus-snapshotter run in host network
+hostNetwork: true
+# -- Host Aliases
+hostAliases: []
+# -- Pod resource requests and limits
+resources:
+  requests:
+    cpu: "0"
+    memory: "0"
+  limits:
+    cpu: "2"
+    memory: "2Gi"
+# -- Pod priorityClassName
+priorityClassName: ""
+# -- Node labels for pod assignment
+nodeSelector: {}
+# -- Pod terminationGracePeriodSeconds
+terminationGracePeriodSeconds:
+# -- List of node taints to tolerate
+tolerations: []
+# -- Pod annotations
+podAnnotations: {}
+# -- Pod labels
+podLabels: {}
+# -- Daemonset annotations
+daemonsetAnnotations: {}
 
 dragonfly:
   # -- Enable dragonfly
@@ -61,7 +51,7 @@ dragonfly:
 # Support: Containerd, Docker, CRI-O
 containerRuntime:
   # -- The image name of init container, just to update container runtime configuration file
-  initContainerImage: ghcr.io/liubin/toml-cli:latest
+  initContainerImage: ghcr.io/liubin/toml-cli:v0.0.7
 
   # -- [Experimental] Containerd support
   containerd:

--- a/charts/nydus-snapshotter/values.yaml
+++ b/charts/nydus-snapshotter/values.yaml
@@ -61,7 +61,7 @@ dragonfly:
 # Support: Containerd, Docker, CRI-O
 containerRuntime:
   # -- The image name of init container, just to update container runtime configuration file
-  initContainerImage: library/alpine:latest
+  initContainerImage: ghcr.io/liubin/toml-cli:latest
 
   # -- [Experimental] Containerd support
   containerd:

--- a/charts/nydus-snapshotter/values.yaml
+++ b/charts/nydus-snapshotter/values.yaml
@@ -1,0 +1,72 @@
+# nydus-snapshotter Helm Chart Values
+
+# -- Override nydus-snapshotter name
+nameOverride: ""
+# -- Override nydus-snapshotter fullname
+fullnameOverride: ""
+
+nydusSnapshotter:
+  # -- nydus-snapshotter name
+  name: nydus-snapshotter
+  # -- Override nydus-snapshotter name
+  nameOverride: ""
+  # -- Override nydus-snapshotter fullname
+  fullnameOverride: ""
+  # -- Image repository
+  image: ghcr.io/containerd/nydus-snapshotter
+  # -- Image tag (FIXME: This version should be updated after a new snapshotter is released.)
+  tag: v1.2.11
+  # -- Image pull policy
+  pullPolicy: Always
+  # -- Let nydus-snapshotter run in host network
+  hostNetwork: true
+  # -- Host Aliases
+  hostAliases: []
+  # -- Pod resource requests and limits
+  resources:
+    requests:
+      cpu: "0"
+      memory: "0"
+    limits:
+      cpu: "2"
+      memory: "2Gi"
+  # -- Pod priorityClassName
+  priorityClassName: ""
+  # -- Node labels for pod assignment
+  nodeSelector: {}
+  # -- Pod terminationGracePeriodSeconds
+  terminationGracePeriodSeconds:
+  # -- List of node taints to tolerate
+  tolerations: []
+  # -- Pod annotations
+  podAnnotations: {}
+  # -- Pod labels
+  podLabels: {}
+  # -- Daemonset annotations
+  daemonsetAnnotations: {}
+
+dragonfly:
+  # -- Enable dragonfly
+  enable: true
+  mirrorConfig:
+    host: "http://127.0.0.1:65001"
+    auth_through: false
+    headers:
+      "X-Dragonfly-Registry": "https://index.docker.io"
+    ping_url: "http://127.0.0.1:40901/server/ping"
+
+
+# -- [Experimental] Container runtime support
+# Choose special container runtime in Kubernetes.
+# Support: Containerd, Docker, CRI-O
+containerRuntime:
+  # -- The image name of init container, just to update container runtime configuration file
+  initContainerImage: library/alpine:latest
+
+  # -- [Experimental] Containerd support
+  containerd:
+    # -- Enable containerd support
+    # Inject nydus-snapshotter config into ${containerRuntime.containerd.configFile},
+    enable: true
+    # -- Custom config path directory, default is /etc/containerd/config.toml
+    configFile: "/etc/containerd/config.toml"


### PR DESCRIPTION
Add new chart for nydus-snapshotter includes:

- daemonset for running nydus-snapshotter inside containers
- a configmap for configuring nydus-snapshotter

Fixes: #127 

Signed-off-by: bin liu <liubin0329@gmail.com>