### PR TITLE
Priorityclass api version & ipv4 nslookup

### DIFF
--- a/charts/dragonfly/templates/dfdaemon/dfdaemon-daemonset.yaml
+++ b/charts/dragonfly/templates/dfdaemon/dfdaemon-daemonset.yaml
@@ -161,7 +161,7 @@ spec:
       - name: wait-for-scheduler
         image: {{ .Values.dfdaemon.initContainer.image }}:{{ .Values.dfdaemon.initContainer.tag  }}
         imagePullPolicy: {{ .Values.dfdaemon.initContainer.pullPolicy }}
-        command: ['sh', '-c', 'until nslookup {{ template "dragonfly.scheduler.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} && nc -vz {{ template "dragonfly.scheduler.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} {{ .Values.scheduler.config.server.port }}; do echo waiting for scheduler; sleep 2; done;']
+        command: ['sh', '-c', 'until nslookup -type=A {{ template "dragonfly.scheduler.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} && nc -vz {{ template "dragonfly.scheduler.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} {{ .Values.scheduler.config.server.port }}; do echo waiting for scheduler; sleep 2; done;']
       {{- end }}
       {{- if and (not .Values.dfdaemon.hostNetwork) .Values.dfdaemon.config.proxy.tcpListen.namespace }}
       - name: mount-netns

--- a/charts/dragonfly/templates/dfdaemon/dfdaemon-daemonset.yaml
+++ b/charts/dragonfly/templates/dfdaemon/dfdaemon-daemonset.yaml
@@ -54,7 +54,7 @@ spec:
       {{- if quote .Values.dfdaemon.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.dfdaemon.terminationGracePeriodSeconds }}
       {{- end }}
-      {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.dfdaemon.priorityClassName) }}
+      {{- if .Values.dfdaemon.priorityClassName }}
       priorityClassName: {{ .Values.dfdaemon.priorityClassName }}
       {{- end }}
       {{- if .Values.dfdaemon.hostAliases }}

--- a/charts/dragonfly/templates/manager/manager-deployment.yaml
+++ b/charts/dragonfly/templates/manager/manager-deployment.yaml
@@ -50,7 +50,7 @@ spec:
       {{- if quote .Values.manager.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.manager.terminationGracePeriodSeconds }}
       {{- end }}
-      {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.scheduler.priorityClassName) }}
+      {{- if .Values.scheduler.priorityClassName }}
       priorityClassName: {{ .Values.manager.priorityClassName }}
       {{- end }}
       {{- if or .Values.redis.enable .Values.mysql.enable }}

--- a/charts/dragonfly/templates/scheduler/scheduler-statefulset.yaml
+++ b/charts/dragonfly/templates/scheduler/scheduler-statefulset.yaml
@@ -63,9 +63,9 @@ spec:
         image: {{ .Values.scheduler.initContainer.image }}:{{ .Values.scheduler.initContainer.tag  }}
         imagePullPolicy: {{ .Values.scheduler.initContainer.pullPolicy }}
         {{- if .Values.manager.enable }}
-        command: ['sh', '-c', 'until nslookup {{ template "dragonfly.manager.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} && nc -vz {{ template "dragonfly.manager.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} {{ .Values.manager.restPort }}; do echo waiting for manager; sleep 2; done;']
+        command: ['sh', '-c', 'until nslookup -type=A {{ template "dragonfly.manager.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} && nc -vz {{ template "dragonfly.manager.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} {{ .Values.manager.restPort }}; do echo waiting for manager; sleep 2; done;']
         {{- else }}
-        command: ['sh', '-c', 'until nslookup {{ .Values.externalManager.host }} && nc -vz {{ .Values.externalManager.host }} {{ .Values.externalManager.restPort }}; do echo waiting for external manager; sleep 2; done;']
+        command: ['sh', '-c', 'until nslookup -type=A {{ .Values.externalManager.host }} && nc -vz {{ .Values.externalManager.host }} {{ .Values.externalManager.restPort }}; do echo waiting for external manager; sleep 2; done;']
         {{- end }}
       containers:
       - name: scheduler

--- a/charts/dragonfly/templates/scheduler/scheduler-statefulset.yaml
+++ b/charts/dragonfly/templates/scheduler/scheduler-statefulset.yaml
@@ -51,7 +51,7 @@ spec:
       {{- if quote .Values.scheduler.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.scheduler.terminationGracePeriodSeconds }}
       {{- end }}
-      {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.scheduler.priorityClassName) }}
+      {{- if .Values.scheduler.priorityClassName }}
       priorityClassName: {{ .Values.scheduler.priorityClassName }}
       {{- end }}
       {{- if .Values.scheduler.hostAliases }}

--- a/charts/dragonfly/templates/seed-peer/seed-peer-statefulset.yaml
+++ b/charts/dragonfly/templates/seed-peer/seed-peer-statefulset.yaml
@@ -51,7 +51,7 @@ spec:
       {{- if quote .Values.seedPeer.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.seedPeer.terminationGracePeriodSeconds }}
       {{- end }}
-      {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.seedPeer.priorityClassName) }}
+      {{- if .Values.seedPeer.priorityClassName }}
       priorityClassName: {{ .Values.seedPeer.priorityClassName }}
       {{- end }}
       {{- if .Values.seedPeer.hostAliases }}

--- a/charts/nydus-snapshotter/templates/nydus-snapshotter/snapshotter-daemonset.yaml
+++ b/charts/nydus-snapshotter/templates/nydus-snapshotter/snapshotter-daemonset.yaml
@@ -50,7 +50,7 @@ spec:
       {{- if quote .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}
-      {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.priorityClassName) }}
+      {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
       {{- if .Values.hostAliases }}


### PR DESCRIPTION
This PR fixes 2 limitations we encounter in our use of Dragonfly's chart:
- Since "scheduling.k8s.io/v1beta1" API is no longer served since kubernetes 1.22, it should not be a requirement to use a PriorityClass
- The nslookup command from the waiting init containers fails if ipv6 resolution is not available which is the case sometimes. Resolution has been limited to ipv4 to ensure compatibility to most cases