### PR TITLE
Modify the pull policy so that the pull policy of busybox is consistent

### DIFF
--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -875,6 +875,8 @@ dfdaemon:
     image: busybox
     # -- Init container image tag
     tag: latest
+    # -- Container image pull policy
+    pullPolicy: IfNotPresent
   # -- Extra volumes for dfdaemon.
   extraVolumes:
     - name: logs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
In values.yaml file, the pull policy of all Pods such as Manager for busybox image is IfNotPresent, except that the pull policy of busybox is not specified in Dfdaemon. Due to the Latest version tag, the pull policy for busybox in Dfdaemon will be resolved to Always by default, which results in  pulling from hub every time I initialize even if I have a local busybox image

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
