### PR TITLE
fix registries is http generate cert.d file name err

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,8 +3,8 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/Dragonfly2/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.0.3
-appVersion: 1.0.3
+version: 1.0.4
+appVersion: 1.0.4
 keywords:
   - dragonfly
   - d7y
@@ -28,6 +28,7 @@ annotations:
   artifacthub.io/changes: |
     - Update image version to v2.1.0-alpha.6.
     - Add redis configuration in scheduler.
+    - fix registries is http generate cert.d file name err
 
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/dragonfly/templates/dfdaemon/dfdaemon-daemonset.yaml
+++ b/charts/dragonfly/templates/dfdaemon/dfdaemon-daemonset.yaml
@@ -404,7 +404,7 @@ spec:
               mkdir -p $etcContainerd/certs.d
               for registry in $registries; do
                 # parse registry domain
-                domain=$(echo $registry | sed -e "s,http.://,," | sed "s,:.*,,")
+                domain=$(echo $registry | sed -e "s,http.*://,," | sed "s,:.*,,")
                 # inject registry
                 mkdir -p $etcContainerd/certs.d/$domain
                 if [[ -e "$etcContainerd/certs.d/$domain/hosts.toml" ]]; then


### PR DESCRIPTION
## Description

when containerRuntime.containerd.registries addr is http then generate cert.d file name err

## Related Issue

https://github.com/dragonflyoss/Dragonfly2/issues/2527

