### PR TITLE
spec.serviceName on STS should be the same as metadata.name on Service

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,8 +3,8 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/Dragonfly2/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.0.3
-appVersion: 1.0.3
+version: 1.0.4
+appVersion: v2.1.0
 keywords:
   - dragonfly
   - d7y

--- a/charts/dragonfly/templates/scheduler/scheduler-statefulset.yaml
+++ b/charts/dragonfly/templates/scheduler/scheduler-statefulset.yaml
@@ -21,7 +21,7 @@ spec:
       app: {{ template "dragonfly.fullname" . }}
       release: {{ .Release.Name }}
       component: {{ .Values.scheduler.name }}
-  serviceName: scheduler
+  serviceName: {{ template "dragonfly.scheduler.fullname" . }}
   template:
     metadata:
       labels:

--- a/charts/dragonfly/templates/seed-peer/seed-peer-statefulset.yaml
+++ b/charts/dragonfly/templates/seed-peer/seed-peer-statefulset.yaml
@@ -21,7 +21,7 @@ spec:
       app: {{ template "dragonfly.fullname" . }}
       component: {{ .Values.seedPeer.name }}
       release: {{ .Release.Name }}
-  serviceName: seed-peer
+  serviceName: {{ template "dragonfly.seedPeer.fullname" . }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
spec.serviceName on STS should be the same as metadata.name on correlating Service

## Description

Fixes the following issue when Release.Name != `dragonfly`

```shell
2023-07-16T06:48:47.621Z	WARN	config/dynconfig_manager.go:124	scheduler x.x.x.x <.Release.Name>-scheduler-0.scheduler.<.Release.Namespace>.svc.cluster.local 8002 has not reachable addresses
```

Also changing the `spec.serviceName` on the seedPeer STS even though a Service does not exist for it. For our use-case we actually creating a Service for it, and I'm planning opening another PR for optionally creating a Service in the official chart

Piggybacking changing the `appVersion` field value on Chart.yaml to the application's version

## Related Issue

https://github.com/dragonflyoss/helm-charts/issues/179
