### PR TITLE
fix the regex when injecting v1 mirror settings

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,8 +3,8 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/Dragonfly2/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.0.5
-appVersion: 1.0.5
+version: 1.0.6
+appVersion: 1.0.6
 keywords:
   - dragonfly
   - d7y
@@ -26,7 +26,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Update regex when checking containerd config.toml.
+    - Fix the regex when injecting v1 mirror settings.
 
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/dragonfly/templates/dfdaemon/dfdaemon-daemonset.yaml
+++ b/charts/dragonfly/templates/dfdaemon/dfdaemon-daemonset.yaml
@@ -360,7 +360,7 @@ spec:
               echo config_path is not enabled, just add one mirror in {{ default "config.toml" .Values.containerRuntime.containerd.configFileName }}
               # parse registry domain
               registry={{ .Values.dfdaemon.config.proxy.registryMirror.url}}
-              domain=$(echo $registry | sed -e "s,https://,," | sed "s,:.*,,")
+              domain=$(echo $registry | sed -e "s,http.*://,," | sed "s,:.*,,")
               # inject registry
               if grep "registry.mirrors.\"$domain\"" $etcContainerd/{{ default "config.toml" .Values.containerRuntime.containerd.configFileName }}; then
                 # TODO merge mirrors
@@ -432,7 +432,7 @@ spec:
             echo containerd config is version 1, just only support one mirror in {{ default "config.toml" .Values.containerRuntime.containerd.configFileName }}
             # parse registry domain
             registry={{ .Values.dfdaemon.config.proxy.registryMirror.url}}
-            domain=$(echo {{ .Values.dfdaemon.config.proxy.registryMirror.url}} | sed -e "s,http.://,," | sed "s,:.*,,")
+            domain=$(echo {{ .Values.dfdaemon.config.proxy.registryMirror.url}} | sed -e "s,http.*://,," | sed "s,:.*,,")
             # inject registry
             if grep "registry.mirrors.\"$domain\"" $etcContainerd/{{ default "config.toml" .Values.containerRuntime.containerd.configFileName }}; then
               # TODO merge mirrors


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix the regex when injecting v1 mirror settings.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

[dragonflyoss/Dragonfly2#2527](https://github.com/dragonflyoss/Dragonfly2/issues/2527)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
