### PR TITLE
Fix command flag '--' for dfdaemon

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,8 +3,8 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/Dragonfly2/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.0.8
-appVersion: 1.0.8
+version: 1.0.9
+appVersion: 1.0.9
 keywords:
   - dragonfly
   - d7y
@@ -26,7 +26,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Add dots to documentation comments.
+    - Fix command flag '--' for dfdaemon.
 
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/dragonfly/templates/dfdaemon/dfdaemon-daemonset.yaml
+++ b/charts/dragonfly/templates/dfdaemon/dfdaemon-daemonset.yaml
@@ -294,23 +294,23 @@ spec:
           {{- if .Values.containerRuntime.docker.restart }}
           # inject docker proxy setting and restart docker
           # currently, without host pid in container, we can not nsenter with pid and can not invoke systemctl correctly.
-          status=$(nsenter -t 1 -m systemctl -- status docker --no-pager | grep http-proxy.conf)
+          status=$(nsenter -t 1 -m -- systemctl status docker --no-pager | grep http-proxy.conf)
           if [[ -n "$status" ]]; then
             echo Docker proxy already enabled, skip
           else
             echo Try to inject proxy and restart docker
-            path=$(nsenter -t 1 -m systemctl -- show -p FragmentPath docker.service | grep -o "/.*systemd.*")
+            path=$(nsenter -t 1 -m -- systemctl show -p FragmentPath docker.service | grep -o "/.*systemd.*")
             if [[ -z "$path" ]]; then
                 echo docker.service not found
                 exit 1
             fi
-            nsenter -t 1 -m mkdir -- -p "$path".d
-            nsenter -t 1 -m sh -- -c "echo '[Service]' > $path.d/http-proxy.conf"
-            nsenter -t 1 -m sh -- -c "echo 'Environment=\"HTTP_PROXY=http://127.0.0.1:{{ .Values.dfdaemon.hostPort}}\"' >> $path.d/http-proxy.conf"
-            nsenter -t 1 -m sh -- -c "echo 'Environment=\"HTTPS_PROXY=http://127.0.0.1:{{ .Values.dfdaemon.hostPort}}\"' >> $path.d/http-proxy.conf"
-            nsenter -t 1 -m sh -- -c "echo 'Environment=\"NO_PROXY={{ join "," .Values.containerRuntime.docker.skipHosts }}\"' >> $path.d/http-proxy.conf"
-            nsenter -t 1 -m systemctl -- daemon-reload
-            nsenter -t 1 -m systemctl -- restart docker.service
+            nsenter -t 1 -m -- mkdir -p "$path".d
+            nsenter -t 1 -m -- sh -c "echo '[Service]' > $path.d/http-proxy.conf"
+            nsenter -t 1 -m -- sh -c "echo 'Environment=\"HTTP_PROXY=http://127.0.0.1:{{ .Values.dfdaemon.hostPort}}\"' >> $path.d/http-proxy.conf"
+            nsenter -t 1 -m -- sh -c "echo 'Environment=\"HTTPS_PROXY=http://127.0.0.1:{{ .Values.dfdaemon.hostPort}}\"' >> $path.d/http-proxy.conf"
+            nsenter -t 1 -m -- sh -c "echo 'Environment=\"NO_PROXY={{ join "," .Values.containerRuntime.docker.skipHosts }}\"' >> $path.d/http-proxy.conf"
+            nsenter -t 1 -m -- systemctl daemon-reload
+            nsenter -t 1 -m -- systemctl restart docker.service
           fi
           {{- end }}
         volumeMounts:
@@ -463,7 +463,7 @@ spec:
           # restart containerd
           # currently, without host pid in container, we can not nsenter with pid and can not invoke systemctl correctly.
           if [[ "$need_restart" -gt 0 ]]; then
-            nsenter -t 1 -m systemctl -- restart containerd.service
+            nsenter -t 1 -m -- systemctl restart containerd.service
           fi
         volumeMounts:
         - name: containerd-conf
@@ -526,7 +526,7 @@ spec:
               echo "Registry $domain added"
             fi
           done
-          nsenter -t 1 -m systemctl -- reload crio.service
+          nsenter -t 1 -m -- systemctl reload crio.service
         volumeMounts:
         - name: etc
           mountPath: /host/etc


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix the helm template of dfdaemon, the position of command flag '--' is incorrect.

<!--- Describe your changes in detail -->

## Related Issue
[deploy Dragonfly in K8S with Helm but HTTP(s) Proxy of docker failed to automatically configure](https://github.com/dragonflyoss/Dragonfly2/issues/2581)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Enable Docker's HTTP(s) proxy to be injected correctly and take effect.

<!--- Why is this change required? What problem does it solve? -->
