### PR TITLE
fix bug cause 'plugins."io.containerd.grpc.v1.cri".registry' duplicated

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/Dragonfly2/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.1.3
+version: 1.1.4
 appVersion: 2.1.0
 keywords:
   - dragonfly
@@ -26,8 +26,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Add registryTimeout to manager preheat config.
-    - Add resource to scheduler config.
+    - Fix bug cause 'plugins."io.containerd.grpc.v1.cri".registry' duplicated in dfdaemon init script(containerd part)
 
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/dragonfly/templates/dfdaemon/dfdaemon-daemonset.yaml
+++ b/charts/dragonfly/templates/dfdaemon/dfdaemon-daemonset.yaml
@@ -394,10 +394,14 @@ spec:
               tmp=$(cat $etcContainerd/{{ default "config.toml" .Values.containerRuntime.containerd.configFileName }} | tr '"' ' ' | grep config_path | awk '{print $3}')
               if [[ -z "$tmp" ]]; then
                 echo inject config_path into $etcContainerd/{{ default "config.toml" .Values.containerRuntime.containerd.configFileName }}
-                cat << EOF >> $etcContainerd/{{ default "config.toml" .Values.containerRuntime.containerd.configFileName }}
+                if grep -q '\[plugins."io.containerd.grpc.v1.cri".registry\]' $etcContainerd/{{ default "config.toml" .Values.containerRuntime.containerd.configFileName }}; then
+                  sed -i 's|\[plugins."io.containerd.grpc.v1.cri".registry\]|\[plugins."io.containerd.grpc.v1.cri".registry\]\nconfig_path = "{{ .Values.containerRuntime.containerd.configPathDir }}/certs.d"|g' $etcContainerd/{{ default "config.toml" .Values.containerRuntime.containerd.configFileName }}
+                else
+                  cat << EOF >> $etcContainerd/{{ default "config.toml" .Values.containerRuntime.containerd.configFileName }}
           [plugins."io.containerd.grpc.v1.cri".registry]
             config_path = "{{ .Values.containerRuntime.containerd.configPathDir }}/certs.d"
           EOF
+                fi
                 echo "Registry config_path $config_path added"
                 need_restart=1
               fi


### PR DESCRIPTION
env: Aliyun ACK
kubernetes: 1.22.15-aliyun.1
containerd: 1.5.13


this commit is for checking the helm script dfdaemon init script's containerd init line exist, then append the cert config after it

## Description

this commit is for checking the line exist, then append the cert config after it

if `[plugins."io.containerd.grpc.v1.cri".registry]` exists in containerd config file, will insert duplicated line `[plugins."io.containerd.grpc.v1.cri".registry]`, which will cause  a containerd fatal error:
```
Aug 11 15:00:34  systemd[1]: containerd.service holdoff time over, scheduling restart.
Aug 11 15:00:34  systemd[1]: Stopped containerd container runtime.
Aug 11 15:00:34  systemd[1]: Starting containerd container runtime...
Aug 11 15:00:34  containerd[501622]: containerd: failed to load TOML: /etc/containerd/config.toml: (72, 2): duplicated tables
Aug 11 15:00:34  systemd[1]: containerd.service: main process exited, code=exited, status=1/FAILURE
Aug 11 15:00:34  systemd[1]: Failed to start containerd container runtime.
Aug 11 15:00:34  systemd[1]: Unit containerd.service entered failed state.
Aug 11 15:00:34  systemd[1]: containerd.service failed.
```

## Motivation and Context

this commit is for checking the line exist, then append the cert config after it
