### PR TITLE
feat: auto detect storage volumeMount while setting it in volumeMounts

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,8 +3,8 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/Dragonfly2/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.1.32
-appVersion: 2.1.31
+version: 1.1.33
+appVersion: 2.1.32
 keywords:
   - dragonfly
   - d7y

--- a/charts/dragonfly/templates/seed-peer/seed-peer-statefulset.yaml
+++ b/charts/dragonfly/templates/seed-peer/seed-peer-statefulset.yaml
@@ -124,12 +124,18 @@ spec:
           items:
           - key: dfget.yaml
             path: dfget.yaml
-      {{- if not (.Values.seedPeer.persistence.enable) }}
-      - name: storage
-        emptyDir: {}
-      {{- end }}
+      {{- $needStorage := true }}
       {{- if .Values.seedPeer.extraVolumes }}
+      {{- range .Values.seedPeer.extraVolumes }}
+      {{- if eq .name "storage" }}
+      {{- $needStorage = false }}
+      {{- end }}
+      {{- end }}
       {{- toYaml .Values.seedPeer.extraVolumes | nindent 6 }}
+      {{- end }}
+      {{- if and (not (.Values.seedPeer.persistence.enable)) $needStorage }}
+      - name: storage
+        emptyDir: { }
       {{- end }}
   {{- if .Values.seedPeer.persistence.enable }}
   volumeClaimTemplates:


### PR DESCRIPTION

## Description

Now we could only use PVC or emptyDir storage for seek-peer in this helm chart. I add a detection in extraVolumeMounts if user sets storage in volumeMounts when there's no persistent storage

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
