### PR TITLE
fix containerd start failed when config.toml already has other proxy_plugins

### DIFF
--- a/charts/nydus-snapshotter/Chart.yaml
+++ b/charts/nydus-snapshotter/Chart.yaml
@@ -3,7 +3,7 @@ name: nydus-snapshotter
 description: Nydus snapshotter is an external plugin of containerd for Nydus image service which implements a chunk-based content-addressable filesystem on top of a called RAFS.
 icon: https://github.com/dragonflyoss/image-service/raw/master/misc/logo.svg
 type: application
-version: 0.0.6
+version: 0.0.7
 appVersion: 0.9.0
 keywords:
   - nydus

--- a/charts/nydus-snapshotter/templates/nydus-snapshotter/snapshotter-daemonset.yaml
+++ b/charts/nydus-snapshotter/templates/nydus-snapshotter/snapshotter-daemonset.yaml
@@ -117,6 +117,13 @@ spec:
           toml set --overwrite $etcContainerd plugins.\"io.containerd.grpc.v1.cri\".containerd.disable_snapshot_annotations false
           toml set --overwrite $etcContainerd plugins.\"io.containerd.grpc.v1.cri\".containerd.snapshotter nydus
 
+          if grep -q "\[proxy_plugins\]" $etcContainerd; then
+            echo '[proxy_plugins.nydus]' >> $etcContainerd
+            echo '  type = "snapshot"' >>  $etcContainerd
+            echo '  address = "/run/containerd-nydus/containerd-nydus-grpc.sock"' >>  $etcContainerd
+            exit 0
+          fi
+
           # toml command not support to set block, so just use cat command.
           cat << EOF >> $etcContainerd
           [proxy_plugins]


### PR DESCRIPTION

## when containerd config.toml has other proxy_plugins,the [proxy_plugins] will conflict with nydus config

          [proxy_plugins]
            [proxy_plugins.nydus]
              type = "snapshot"
              address = "/run/containerd-nydus/containerd-nydus-grpc.sock"


so containerd cannot restart success
