### PR TITLE
nydus-snapshotter: fix snapshotter version in README

### DIFF
--- a/charts/nydus-snapshotter/Chart.yaml
+++ b/charts/nydus-snapshotter/Chart.yaml
@@ -3,7 +3,7 @@ name: nydus-snapshotter
 description: Nydus snapshotter is an external plugin of containerd for Nydus image service which implements a chunk-based content-addressable filesystem on top of a called RAFS.
 icon: https://github.com/dragonflyoss/image-service/raw/master/misc/logo.svg
 type: application
-version: 0.0.7
+version: 0.0.8
 appVersion: 0.9.0
 keywords:
   - nydus

--- a/charts/nydus-snapshotter/README.md
+++ b/charts/nydus-snapshotter/README.md
@@ -36,7 +36,7 @@ Create the `values.yaml` configuration file.
 nydusSnapshotter:
   name: nydus-snapshotter
   image: ghcr.io/containerd/nydus-snapshotter
-  tag: v1.2.11
+  tag: v0.13.4
 ```
 Install nydus-snapshotter chart with release name `nydus-snapshotter`:
 

--- a/charts/nydus-snapshotter/README.md.gotmpl
+++ b/charts/nydus-snapshotter/README.md.gotmpl
@@ -37,7 +37,7 @@ Create the `values.yaml` configuration file.
 nydusSnapshotter:
   name: nydus-snapshotter
   image: ghcr.io/containerd/nydus-snapshotter
-  tag: v1.2.11
+  tag: v0.13.4
 ```
 Install nydus-snapshotter chart with release name `nydus-snapshotter`:
 


### PR DESCRIPTION
There is no version 1.2.11 of nydus snapshotter.
Fix it to use the latest available version (v0.13.4) instead.

Fixes #211