### PR TITLE
Add domain name port when modifying containerd injection configuration.

### DIFF
--- a/charts/dragonfly/templates/dfdaemon/dfdaemon-daemonset.yaml
+++ b/charts/dragonfly/templates/dfdaemon/dfdaemon-daemonset.yaml
@@ -369,7 +369,7 @@ spec:
               echo config_path is not enabled, just add one mirror in {{ default "config.toml" .Values.containerRuntime.containerd.configFileName }}
               # parse registry domain
               registry={{ .Values.dfdaemon.config.proxy.registryMirror.url}}
-              domain=$(echo $registry | sed -e "s,http.*://,," | sed "s,:.*,,")
+              domain=$(echo $registry | sed -e "s,http.*://,,")
               # inject registry
               if grep "registry.mirrors.\"$domain\"" $etcContainerd/{{ default "config.toml" .Values.containerRuntime.containerd.configFileName }}; then
                 # TODO merge mirrors
@@ -426,7 +426,7 @@ spec:
                     registry_domain=$registry
                 fi
                 # parse registry domain
-                domain=$(echo $registry | sed -e "s,http.*://,," | sed "s,:.*,,")
+                domain=$(echo $registry | sed -e "s,http.*://,,")
                 # inject registry
                 mkdir -p $etcContainerd/certs.d/$domain
                 if [[ -e "$etcContainerd/certs.d/$domain/hosts.toml" ]]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If the mirror repository is in the form of domain name plus port, the port needs to be added when it is injected into the /etc/containerd/certs.d/

