### PR TITLE
fix: the registry host namespace should include the port

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/Dragonfly2/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.1.24
+version: 1.1.25
 appVersion: 2.1.30
 keywords:
   - dragonfly
@@ -26,9 +26,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Change structure of the metrics config in client.
-    - Update dragonfly image tag to v2.1.30.
-    - Update client image tag to v0.1.13.
+    - Fix the registry host namespace in dfdaemon
 
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/dragonfly/templates/dfdaemon/dfdaemon-daemonset.yaml
+++ b/charts/dragonfly/templates/dfdaemon/dfdaemon-daemonset.yaml
@@ -426,7 +426,7 @@ spec:
                     registry_domain=$registry
                 fi
                 # parse registry domain
-                domain=$(echo $registry | sed -e "s,http.*://,," | sed "s,:.*,,")
+                domain=$(echo $registry | sed -e "s,http.*://,,")
                 # inject registry
                 mkdir -p $etcContainerd/certs.d/$domain
                 if [[ -e "$etcContainerd/certs.d/$domain/hosts.toml" ]]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

According to the container documentation, the registry host namespace should include a port. I have also tested this in practice; the `hosts.toml` configuration under the `certs.d/127.0.0.1` directory indeed does not affect `crictl pull 127.0.0.1:5000/xxx`. Therefore, you should create a `certs.d/127.0.0.1:5000` directory.

https://github.com/containerd/containerd/blob/main/docs/hosts.md#registry-host-namespace

<img width="858" alt="image" src="https://github.com/dragonflyoss/helm-charts/assets/1206493/83aee9d5-3529-48f1-a985-d7a2cd2618d7">


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Solve the issue of invalid mirror for registry with port.