### PR TITLE
move manager & scheduler configs in secrets

### DIFF
--- a/charts/dragonfly/templates/manager/manager-deployment.yaml
+++ b/charts/dragonfly/templates/manager/manager-deployment.yaml
@@ -33,7 +33,7 @@ spec:
 {{ toYaml .Values.manager.podLabels | indent 8 }}
         {{- end }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/manager/manager-configmap.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/manager/manager-secret.yaml") . | sha256sum }}
       {{- if .Values.manager.podAnnotations }}
 {{ toYaml .Values.manager.podAnnotations | indent 8 }}
       {{- end }}
@@ -132,7 +132,7 @@ spec:
       {{- end }}
       volumes:
       - name: config
-        configMap:
+        secret:
           name: {{ template "dragonfly.manager.fullname" . }}
           items:
           - key: manager.yaml

--- a/charts/dragonfly/templates/manager/manager-secret.yaml
+++ b/charts/dragonfly/templates/manager/manager-secret.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.manager.enable }}
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: {{ template "dragonfly.manager.fullname" . }}
   labels:

--- a/charts/dragonfly/templates/scheduler/scheduler-secret.yaml
+++ b/charts/dragonfly/templates/scheduler/scheduler-secret.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.scheduler.enable }}
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: {{ template "dragonfly.scheduler.fullname" . }}
   labels:

--- a/charts/dragonfly/templates/scheduler/scheduler-statefulset.yaml
+++ b/charts/dragonfly/templates/scheduler/scheduler-statefulset.yaml
@@ -35,7 +35,7 @@ spec:
 {{ toYaml .Values.scheduler.podLabels | indent 8 }}
         {{- end }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/scheduler/scheduler-configmap.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/scheduler/scheduler-secret.yaml") . | sha256sum }}
       {{- if .Values.scheduler.podAnnotations }}
 {{ toYaml .Values.scheduler.podAnnotations | indent 8 }}
       {{- end }}
@@ -111,7 +111,7 @@ spec:
           periodSeconds: 10
       volumes:
       - name: config
-        configMap:
+        secret:
           name: {{ template "dragonfly.scheduler.fullname" . }}
           items:
           - key: scheduler.yaml


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Move the manager and scheduler configuration from configmap to secrets

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fix #244 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Database and redis passwords are currently stored in configmaps which is insecure.