### PR TITLE
crio adaptation

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/Dragonfly2/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.1.45
+version: 1.1.46
 appVersion: 2.1.40
 keywords:
   - dragonfly

--- a/charts/dragonfly/templates/dfdaemon/dfdaemon-daemonset.yaml
+++ b/charts/dragonfly/templates/dfdaemon/dfdaemon-daemonset.yaml
@@ -172,7 +172,7 @@ spec:
             add:
             - SYS_ADMIN
         {{- end }}
-      {{- if or (and (not .Values.dfdaemon.hostNetwork) .Values.dfdaemon.config.proxy.tcpListen.namespace) .Values.containerRuntime.containerd.enable .Values.containerRuntime.docker.enable .Values.containerRuntime.extraInitContainers }}
+      {{- if or (and (not .Values.dfdaemon.hostNetwork) .Values.dfdaemon.config.proxy.tcpListen.namespace) .Values.containerRuntime.containerd.enable .Values.containerRuntime.docker.enable .Values.containerRuntime.crio.enable .Values.containerRuntime.extraInitContainers }}
       initContainers:
       {{- if .Values.scheduler.enable }}
       - name: wait-for-scheduler


### PR DESCRIPTION
when runtime is crio，helm-charts can't start dfdaemon initcontainer with 
```yaml
containerRuntime:
  crio:
    enable: true
    injectConfigPath: true
```