### PR TITLE
fix: spec.podMetricsEndpoints.port need to be string

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/Dragonfly2/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.1.57
+version: 1.1.58
 appVersion: 2.1.44
 keywords:
   - dragonfly
@@ -26,7 +26,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Fix metric port for monitor.
+    - Fix spec.podMetricsEndpoints.port need to be string.
 
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/dragonfly/templates/client/podmonitor.yaml
+++ b/charts/dragonfly/templates/client/podmonitor.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- end }}
 spec:
   podMetricsEndpoints:
-  - port: {{ .Values.client.config.metrics.server.port }}
+  - port: {{ .Values.client.config.metrics.server.port | quote }}
     path: /metrics
     {{- if .Values.client.metrics.podMonitor.interval }}
     interval: {{ .Values.client.metrics.podMonitor.interval }}

--- a/charts/dragonfly/templates/dfdaemon/podmonitor.yaml
+++ b/charts/dragonfly/templates/dfdaemon/podmonitor.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- end }}
 spec:
   podMetricsEndpoints:
-  - port: 8000
+  - port: "8000"
     path: /metrics
     {{- if .Values.dfdaemon.metrics.podMonitor.interval }}
     interval: {{ .Values.dfdaemon.metrics.podMonitor.interval }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
