### PR TITLE
Removed the condition validation with scheduling.k8s.io/v1beta1 when applying Priorityclassname

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/Dragonfly2/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.2.2
+version: 1.2.3
 appVersion: 2.1.55
 keywords:
   - dragonfly

--- a/charts/dragonfly/templates/client/client-daemonset.yaml
+++ b/charts/dragonfly/templates/client/client-daemonset.yaml
@@ -60,7 +60,7 @@ spec:
       {{- if quote .Values.client.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.client.terminationGracePeriodSeconds }}
       {{- end }}
-      {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.client.priorityClassName) }}
+      {{- if .Values.client.priorityClassName }}
       priorityClassName: {{ .Values.client.priorityClassName }}
       {{- end }}
       {{- with .Values.client.image.pullSecrets | default .Values.global.imagePullSecrets }}

--- a/charts/dragonfly/templates/manager/manager-deployment.yaml
+++ b/charts/dragonfly/templates/manager/manager-deployment.yaml
@@ -54,7 +54,7 @@ spec:
       {{- if quote .Values.manager.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.manager.terminationGracePeriodSeconds }}
       {{- end }}
-      {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.scheduler.priorityClassName) }}
+      {{- if .Values.scheduler.priorityClassName }}
       priorityClassName: {{ .Values.manager.priorityClassName }}
       {{- end }}
       {{- with .Values.manager.image.pullSecrets | default .Values.global.imagePullSecrets }}

--- a/charts/dragonfly/templates/scheduler/scheduler-statefulset.yaml
+++ b/charts/dragonfly/templates/scheduler/scheduler-statefulset.yaml
@@ -56,7 +56,7 @@ spec:
       {{- if quote .Values.scheduler.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.scheduler.terminationGracePeriodSeconds }}
       {{- end }}
-      {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.scheduler.priorityClassName) }}
+      {{- if .Values.scheduler.priorityClassName }}
       priorityClassName: {{ .Values.scheduler.priorityClassName }}
       {{- end }}
       {{- with .Values.scheduler.image.pullSecrets | default .Values.global.imagePullSecrets }}

--- a/charts/dragonfly/templates/seed-client/seed-client-statefulset.yaml
+++ b/charts/dragonfly/templates/seed-client/seed-client-statefulset.yaml
@@ -56,7 +56,7 @@ spec:
       {{- if quote .Values.seedClient.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.seedClient.terminationGracePeriodSeconds }}
       {{- end }}
-      {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.seedClient.priorityClassName) }}
+      {{- if .Values.seedClient.priorityClassName }}
       priorityClassName: {{ .Values.seedClient.priorityClassName }}
       {{- end }}
       {{- with .Values.seedClient.image.pullSecrets | default .Values.global.imagePullSecrets }}


### PR DESCRIPTION


## Description

The PriorityClass setting is not working as expected because the cluster is running EKS version 1.28, where the scheduling.k8s.io/v1beta1 API version has been deprecated. Currently, the chart is checking for scheduling.k8s.io/v1beta1, which is causing issues. This problem is evident in the Helm chart file at [client-daemonset.yaml#L63](https://github.com/dragonflyoss/helm-charts/blob/main/charts/dragonfly/templates/client/client-daemonset.yaml#L63).

As of Kubernetes v1.22, the scheduling.k8s.io/v1beta1 API version for PriorityClass is no longer served. Consequently, the priorityclassname configuration is not being applied correctly.

Reference:

For more information, refer to the [Kubernetes deprecation guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#priorityclass-v122).

## Related Issue
https://github.com/dragonflyoss/helm-charts/issues/311

## Motivation and Context

I can apply the Priorityclassname whatever is required for my cluster.

