### PR TITLE
feat: add nodePort for services

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/Dragonfly2/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.2.13
+version: 1.2.14
 appVersion: 2.1.56
 keywords:
   - dragonfly
@@ -27,7 +27,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Change job ratelimit to 10 in manager.
+    - Add nodePort for services.
 
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -335,6 +335,7 @@ helm delete dragonfly --namespace dragonfly-system
 | manager.restPort | int | `8080` | REST service port. |
 | manager.service.annotations | object | `{}` | Service annotations. |
 | manager.service.labels | object | `{}` | Service labels. |
+| manager.service.nodePort | string | `""` | Service nodePort. |
 | manager.service.type | string | `"ClusterIP"` | Service type. |
 | manager.terminationGracePeriodSeconds | string | `nil` | Pod terminationGracePeriodSeconds. |
 | manager.tolerations | list | `[]` | List of node taints to tolerate. |
@@ -450,6 +451,7 @@ helm delete dragonfly --namespace dragonfly-system
 | scheduler.resources | object | `{"limits":{"cpu":"4","memory":"8Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits. |
 | scheduler.service.annotations | object | `{}` | Service annotations. |
 | scheduler.service.labels | object | `{}` | Service labels. |
+| scheduler.service.nodePort | string | `""` | Service nodePort. |
 | scheduler.service.type | string | `"ClusterIP"` | Service type. |
 | scheduler.statefulsetAnnotations | object | `{}` | Statefulset annotations. |
 | scheduler.terminationGracePeriodSeconds | string | `nil` | Pod terminationGracePeriodSeconds. |
@@ -536,6 +538,7 @@ helm delete dragonfly --namespace dragonfly-system
 | seedClient.resources | object | `{"limits":{"cpu":"2","memory":"4Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits. |
 | seedClient.service.annotations | object | `{}` | Service annotations. |
 | seedClient.service.labels | object | `{}` | Service labels. |
+| seedClient.service.nodePort | string | `""` | Service nodePort. |
 | seedClient.service.type | string | `"ClusterIP"` | Service type. |
 | seedClient.statefulsetAnnotations | object | `{}` | Statefulset annotations. |
 | seedClient.terminationGracePeriodSeconds | string | `nil` | Pod terminationGracePeriodSeconds. |

--- a/charts/dragonfly/templates/manager/manager-svc.yaml
+++ b/charts/dragonfly/templates/manager/manager-svc.yaml
@@ -28,6 +28,9 @@ spec:
       name: http-grpc
       protocol: TCP
       targetPort: {{ .Values.manager.grpcPort }}
+{{- if eq .Values.manager.service.type "NodePort" }}
+      nodePort: {{ .Values.manager.service.nodePort }}
+{{- end }}
   selector:
     app: {{ template "dragonfly.fullname" . }}
     release: {{ .Release.Name }}

--- a/charts/dragonfly/templates/scheduler/scheduler-svc.yaml
+++ b/charts/dragonfly/templates/scheduler/scheduler-svc.yaml
@@ -24,6 +24,9 @@ spec:
       name: http-grpc
       protocol: TCP
       targetPort: {{ .Values.scheduler.config.server.port }}
+{{- if eq .Values.scheduler.service.type "NodePort" }}
+      nodePort: {{ .Values.scheduler.service.nodePort }}
+{{- end }}
   selector:
     app: {{ template "dragonfly.fullname" . }}
     release: {{ .Release.Name }}

--- a/charts/dragonfly/templates/seed-client/seed-client-svc.yaml
+++ b/charts/dragonfly/templates/seed-client/seed-client-svc.yaml
@@ -32,6 +32,9 @@ spec:
       name: http-stats
       protocol: TCP
       targetPort: {{ .Values.seedClient.config.stats.server.port }}
+{{- if eq .Values.seedClient.service.type "NodePort" }}
+      nodePort: {{ .Values.seedClient.service.nodePort }}
+{{- end }}
   selector:
     app: {{ template "dragonfly.fullname" . }}
     release: {{ .Release.Name }}

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -93,6 +93,8 @@ manager:
     labels: {}
     # -- Service annotations.
     annotations: {}
+    # -- Service nodePort.
+    nodePort: ""
   initContainer:
     # -- Pod resource requests and limits.
     resources:
@@ -372,6 +374,8 @@ scheduler:
     labels: {}
     # -- Service annotations.
     annotations: {}
+    # -- Service nodePort.
+    nodePort: ""
   # -- Pod priorityClassName.
   priorityClassName: ""
   # -- Node labels for pod assignment.
@@ -840,6 +844,8 @@ seedClient:
     labels: {}
     # -- Service annotations.
     annotations: {}
+    # -- Service nodePort.
+    nodePort: ""
   config:
     # -- verbose prints log.
     verbose: true


### PR DESCRIPTION
## Description

Add `nodePort` for scheduler, manager and seed-client services, so that nodePort can be configured when the service type is `nodePort`.

## Related Issue

https://github.com/dragonflyoss/Dragonfly2/issues/3523
