### PR TITLE
feat: change LFU size to 50000 in manager cache

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.2.27
+version: 1.2.28
 appVersion: 2.1.65
 keywords:
   - dragonfly
@@ -27,7 +27,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Rename repo Dragonfly2 to dragonfly.
+    - Change LFU size to 50000 in the manager cache.
 
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -244,7 +244,7 @@ helm delete dragonfly --namespace dragonfly-system
 | manager.config.auth.jwt.maxRefresh | string | `"48h"` | MaxRefresh field allows clients to refresh their token until MaxRefresh has passed, default duration is two days. |
 | manager.config.auth.jwt.realm | string | `"Dragonfly"` | Realm name to display to the user, default value is Dragonfly. |
 | manager.config.auth.jwt.timeout | string | `"48h"` | Timeout is duration that a jwt token is valid, default duration is two days. |
-| manager.config.cache.local.size | int | `200000` | Size of LFU cache. |
+| manager.config.cache.local.size | int | `50000` | Size of LFU cache. |
 | manager.config.cache.local.ttl | string | `"3m"` | Local cache TTL duration. |
 | manager.config.cache.redis.ttl | string | `"5m"` | Redis cache TTL duration. |
 | manager.config.console | bool | `true` | Console shows log on console. |

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -177,7 +177,7 @@ manager:
         ttl: 5m
       local:
         # -- Size of LFU cache.
-        size: 200000
+        size: 50000
         # -- Local cache TTL duration.
         ttl: 3m
     job:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request involves updates to the Dragonfly Helm chart, specifically focusing on the version bump and changes to the cache size configuration. The most important changes include updating the chart version, modifying the LFU cache size, and updating related documentation.

Version update:
* [`charts/dragonfly/Chart.yaml`](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L6-R6): Updated the chart version from `1.2.27` to `1.2.28`.

Cache configuration changes:
* [`charts/dragonfly/values.yaml`](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL180-R180): Changed the LFU cache size from `200000` to `50000`.
* [`charts/dragonfly/Chart.yaml`](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L30-R30): Updated the `artifacthub.io/changes` annotation to reflect the change in LFU cache size.
* [`charts/dragonfly/README.md`](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL247-R247): Updated the documentation to reflect the new LFU cache size of `50000`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
