### PR TITLE
feat: change job and cache config for manager

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.2.28
+version: 1.2.29
 appVersion: 2.1.65
 keywords:
   - dragonfly
@@ -27,7 +27,8 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Change LFU size to 50000 in the manager cache.
+    - Change LFU size to 30000 in the manager cache.
+    - Change job GC TTL and interval in manager.
 
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -244,14 +244,14 @@ helm delete dragonfly --namespace dragonfly-system
 | manager.config.auth.jwt.maxRefresh | string | `"48h"` | MaxRefresh field allows clients to refresh their token until MaxRefresh has passed, default duration is two days. |
 | manager.config.auth.jwt.realm | string | `"Dragonfly"` | Realm name to display to the user, default value is Dragonfly. |
 | manager.config.auth.jwt.timeout | string | `"48h"` | Timeout is duration that a jwt token is valid, default duration is two days. |
-| manager.config.cache.local.size | int | `50000` | Size of LFU cache. |
+| manager.config.cache.local.size | int | `30000` | Size of LFU cache. |
 | manager.config.cache.local.ttl | string | `"3m"` | Local cache TTL duration. |
 | manager.config.cache.redis.ttl | string | `"5m"` | Redis cache TTL duration. |
 | manager.config.console | bool | `true` | Console shows log on console. |
 | manager.config.jaeger | string | `""` |  |
-| manager.config.job.gc | object | `{"interval":"24h","ttl":"24h"}` | gc configuration. |
-| manager.config.job.gc.interval | string | `"24h"` | interval is the interval of gc. |
-| manager.config.job.gc.ttl | string | `"24h"` | ttl is the ttl of job. |
+| manager.config.job.gc | object | `{"interval":"3h","ttl":"6h"}` | gc configuration. |
+| manager.config.job.gc.interval | string | `"3h"` | interval is the interval of gc. |
+| manager.config.job.gc.ttl | string | `"6h"` | ttl is the ttl of job. |
 | manager.config.job.preheat | object | `{"registryTimeout":"1m","tls":{"insecureSkipVerify":false}}` | Preheat configuration. |
 | manager.config.job.preheat.registryTimeout | string | `"1m"` | registryTimeout is the timeout for requesting registry to get token and manifest. |
 | manager.config.job.preheat.tls.insecureSkipVerify | bool | `false` | insecureSkipVerify controls whether a client verifies the server's certificate chain and hostname. |

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -177,7 +177,7 @@ manager:
         ttl: 5m
       local:
         # -- Size of LFU cache.
-        size: 50000
+        size: 30000
         # -- Local cache TTL duration.
         ttl: 3m
     job:
@@ -192,9 +192,9 @@ manager:
       # -- gc configuration.
       gc:
         # -- interval is the interval of gc.
-        interval: 24h
+        interval: 3h
         # -- ttl is the ttl of job.
-        ttl: 24h
+        ttl: 6h
       # -- Sync peers configuration.
       syncPeers:
         # -- interval is the interval for syncing all peers information from the scheduler and


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes several updates to the Dragonfly Helm chart, primarily focusing on configuration changes to the manager cache and job garbage collection (GC) settings. The most important changes are summarized below:

### Version Update:
* Updated the chart version from `1.2.28` to `1.2.29` in `charts/dragonfly/Chart.yaml`.

### Cache Configuration Changes:
* Changed the LFU cache size from `50000` to `30000` in `charts/dragonfly/Chart.yaml`, `charts/dragonfly/README.md`, and `charts/dragonfly/values.yaml` [[1]](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L30-R31) [[2]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL247-R254) [[3]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL180-R180).

### Job GC Configuration Changes:
* Updated the job GC interval from `24h` to `3h` and the TTL from `24h` to `6h` in `charts/dragonfly/Chart.yaml`, `charts/dragonfly/README.md`, and `charts/dragonfly/values.yaml` [[1]](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L30-R31) [[2]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL247-R254) [[3]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL195-R197).
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
