### PR TITLE
add mount config for docker and podman volume

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.3.0
+version: 1.3.1
 appVersion: 2.2.0
 keywords:
   - dragonfly

--- a/charts/dragonfly/templates/client/client-daemonset.yaml
+++ b/charts/dragonfly/templates/client/client-daemonset.yaml
@@ -100,6 +100,14 @@ spec:
         - name: crio-config-dir
           mountPath: {{ dir .Values.client.dfinit.config.containerRuntime.crio.configPath }}
         {{- end }}
+        {{- if and (.Values.client.dfinit.enable) (.Values.client.dfinit.config.containerRuntime.podman) }}
+        - name: podman-config-dir
+          mountPath: {{ dir .Values.client.dfinit.config.containerRuntime.podman.configPath }}
+        {{- end }}
+        {{- if and (.Values.client.dfinit.enable) (.Values.client.dfinit.config.containerRuntime.docker) }}
+        - name: docker-config-dir
+          mountPath: {{ dir .Values.client.dfinit.config.containerRuntime.docker.configPath }}
+        {{- end }}
       {{- end }}
       {{- if .Values.client.dfinit.enable }}
       - name: restart-container-runtime
@@ -118,6 +126,12 @@ spec:
           {{- else if .Values.client.dfinit.config.containerRuntime.crio }}
           nsenter -t 1 -m -- systemctl restart crio.service
           echo "restart cri-o"
+          {{- else if .Values.client.dfinit.config.containerRuntime.podman }}
+          nsenter -t 1 -m -- systemctl restart podman.service
+          echo "restart podman"
+          {{- else if .Values.client.dfinit.config.containerRuntime.docker }}
+          nsenter -t 1 -m -- systemctl restart docker.service
+          echo "restart docker"
           {{- else }}
           echo "no container runtime to restart"
           {{- end }}
@@ -186,6 +200,18 @@ spec:
       - name: crio-config-dir
         hostPath:
           path: {{ dir .Values.client.dfinit.config.containerRuntime.crio.configPath }}
+          type: DirectoryOrCreate
+      {{- end }}
+      {{- if and (.Values.client.dfinit.enable) (.Values.client.dfinit.config.containerRuntime.podman) }}
+      - name: podman-config-dir
+        hostPath:
+          path: {{ dir .Values.client.dfinit.config.containerRuntime.podman.configPath }}
+          type: DirectoryOrCreate
+      {{- end }}
+      {{- if and (.Values.client.dfinit.enable) (.Values.client.dfinit.config.containerRuntime.docker) }}
+      - name: docker-config-dir
+        hostPath:
+          path: {{ dir .Values.client.dfinit.config.containerRuntime.docker.configPath }}
           type: DirectoryOrCreate
       {{- end }}
       {{- if .Values.client.extraVolumes }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

we missed the mount config for runtime: ```docker``` and ```podman```. Without the mount, the dfinit is not able to apply the modification on the host.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/dragonflyoss/dragonfly/issues/3745

