### PR TITLE
feat: export unix domain socket(UDS) to host

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.3.2
+version: 1.3.3
 appVersion: 2.2.0
 keywords:
   - dragonfly
@@ -27,7 +27,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Update client version to 0.2.1.
+    - Export unix domain socket(UDS) to host.
 
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/dragonfly/templates/client/client-daemonset.yaml
+++ b/charts/dragonfly/templates/client/client-daemonset.yaml
@@ -178,6 +178,8 @@ spec:
         volumeMounts:
         - name: config
           mountPath: "/etc/dragonfly"
+        - mountPath: /var/run/dragonfly
+          name: socket-dir
         {{- if .Values.client.extraVolumeMounts }}
         {{- toYaml .Values.client.extraVolumeMounts | nindent 8 }}
         {{- end }}
@@ -185,6 +187,10 @@ spec:
       - name: config
         configMap:
           name: {{ template "dragonfly.client.fullname" . }}
+      - name: socket-dir
+        hostPath:
+            path: /var/run/dragonfly
+            type: DirectoryOrCreate
       {{- if .Values.client.dfinit.enable }}
       - name: dfinit-config
         configMap:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes updates to the `dragonfly` chart to add support for exporting a Unix domain socket (UDS) to the host, along with a version bump for the chart.

Key changes include:

* **Version Update:**
  * [`charts/dragonfly/Chart.yaml`](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L6-R6): Updated the chart version from `1.3.2` to `1.3.3`.

* **Annotations Update:**
  * [`charts/dragonfly/Chart.yaml`](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L30-R30): Updated the `artifacthub.io/changes` annotation to reflect the new feature of exporting a Unix domain socket (UDS) to the host.

* **Template Update:**
  * [`charts/dragonfly/templates/client/client-daemonset.yaml`](diffhunk://#diff-8cf66934693161309da9877cfb771789762f3385911bfbef625d3990182de2f9R181-R193): Added a volume mount for the Unix domain socket directory and configured it to be created on the host if it does not exist.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
