### PR TITLE
feat: optimize volumes and volumeMounts for unix domain socket(UDS)

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.3.3
+version: 1.3.4
 appVersion: 2.2.0
 keywords:
   - dragonfly
@@ -27,7 +27,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Export unix domain socket(UDS) to host.
+    - Optimize volumes and volumeMounts for unix domain socket(UDS).
 
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/dragonfly/templates/client/client-daemonset.yaml
+++ b/charts/dragonfly/templates/client/client-daemonset.yaml
@@ -178,8 +178,8 @@ spec:
         volumeMounts:
         - name: config
           mountPath: "/etc/dragonfly"
-        - mountPath: /var/run/dragonfly
-          name: socket-dir
+        - name: socket-dir
+          mountPath: /var/run/dragonfly
         {{- if .Values.client.extraVolumeMounts }}
         {{- toYaml .Values.client.extraVolumeMounts | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes updates to the Dragonfly Helm chart to improve volume mounts and update the version. The most important changes include updating the version number, optimizing volume mounts for the Unix domain socket, and reordering the `volumeMounts` entries for clarity.

Version update:

* [`charts/dragonfly/Chart.yaml`](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L6-R6): Updated the chart version from `1.3.3` to `1.3.4`.

Optimizations and reordering:

* [`charts/dragonfly/Chart.yaml`](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L30-R30): Updated the `artifacthub.io/changes` annotation to reflect the optimization of volumes and volumeMounts for the Unix domain socket.
* [`charts/dragonfly/templates/client/client-daemonset.yaml`](diffhunk://#diff-8cf66934693161309da9877cfb771789762f3385911bfbef625d3990182de2f9L181-R182): Reordered the `volumeMounts` entries to place `name` before `mountPath` for the Unix domain socket.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
