### PR TITLE
feat: use emptyDir for the DaemonSet to avoid issues associated with volume mounts using hostPath

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.3.7
+version: 1.3.8
 appVersion: 2.2.1-rc.0
 keywords:
   - dragonfly
@@ -27,7 +27,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Update client version to 0.2.11.
+    - Use emptyDir for the DaemonSet to avoid issues associated with volume mounts using hostPath.
 
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -177,7 +177,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.dfinit.image.tag | string | `"v0.2.11"` | Image tag. |
 | client.enable | bool | `true` | Enable client. |
 | client.extraVolumeMounts | list | `[{"mountPath":"/var/lib/dragonfly/","name":"storage"},{"mountPath":"/var/log/dragonfly/dfdaemon/","name":"logs"}]` | Extra volumeMounts for dfdaemon. |
-| client.extraVolumes | list | `[{"hostPath":{"path":"/var/lib/dragonfly/","type":"DirectoryOrCreate"},"name":"storage"},{"emptyDir":{},"name":"logs"}]` | Extra volumes for dfdaemon. |
+| client.extraVolumes | list | `[{"emptyDir":{},"name":"storage"},{"emptyDir":{},"name":"logs"}]` | Extra volumes for dfdaemon. |
 | client.fullnameOverride | string | `""` | Override scheduler fullname. |
 | client.hostAliases | list | `[]` | Host Aliases. |
 | client.hostIPC | bool | `true` | hostIPC specify if host IPC should be enabled for peer pod. |

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -1146,9 +1146,7 @@ client:
   # -- Extra volumes for dfdaemon.
   extraVolumes:
     - name: storage
-      hostPath:
-        path: /var/lib/dragonfly/
-        type: DirectoryOrCreate
+      emptyDir: {}
     - name: logs
       emptyDir: {}
   # -- Extra volumeMounts for dfdaemon.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes updates to the Dragonfly Helm chart to address issues with volume mounts and to update the version. The most important changes are related to modifying the volume configuration and updating the version number.

Version update:

* [`charts/dragonfly/Chart.yaml`](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L6-R6): Updated the chart version from `1.3.7` to `1.3.8`.

Volume configuration changes:

* [`charts/dragonfly/Chart.yaml`](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L30-R30): Updated the `artifacthub.io/changes` annotation to reflect the use of `emptyDir` for the DaemonSet instead of `hostPath`.
* [`charts/dragonfly/README.md`](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL180-R180): Changed the `client.extraVolumes` configuration to use `emptyDir` for both `storage` and `logs` instead of `hostPath`.
* [`charts/dragonfly/values.yaml`](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL1149-R1149): Modified the `client.extraVolumes` configuration to use `emptyDir` for `storage` instead of `hostPath`.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/dragonflyoss/dragonfly/issues/3811
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
