### PR TITLE
fix: specify protocol for grpc services to instruct Istio

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.3.9
+version: 1.3.10
 appVersion: 2.2.1-rc.0
 keywords:
   - dragonfly

--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -27,7 +27,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Add request rate limit for client's grpc server.
+    - Support Istio by specifying the appProtocol type for services
 
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/dragonfly/templates/manager/manager-svc.yaml
+++ b/charts/dragonfly/templates/manager/manager-svc.yaml
@@ -26,6 +26,7 @@ spec:
       targetPort: {{ .Values.manager.restPort }}
     - port: {{ .Values.manager.grpcPort }}
       name: http-grpc
+      appProtocol: grpc
       protocol: TCP
       targetPort: {{ .Values.manager.grpcPort }}
 {{- if eq .Values.manager.service.type "NodePort" }}

--- a/charts/dragonfly/templates/scheduler/scheduler-svc.yaml
+++ b/charts/dragonfly/templates/scheduler/scheduler-svc.yaml
@@ -22,6 +22,7 @@ spec:
   ports:
     - port: {{ .Values.scheduler.config.server.port }}
       name: http-grpc
+      appProtocol: grpc
       protocol: TCP
       targetPort: {{ .Values.scheduler.config.server.port }}
 {{- if eq .Values.scheduler.service.type "NodePort" }}


### PR DESCRIPTION
Dragonfly is not working with Istio (sidecar injection). The scheduler fails to start as it seems like it can't connect to other components with gRPC calls. This prevents all other components from running.

## Description

Istio selects the wrong protocol. We can fix that by adding appProtocol: grpc to the Dragonfly services. More info here: https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/

## Related Issue
https://github.com/dragonflyoss/helm-charts/issues/350

## Motivation and Context

It adds support for Istio mesh. 