### PR TITLE
fix: correct indentation in client-daemonset.yaml hostPath

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.3.15
+version: 1.3.16
 appVersion: 2.2.1
 keywords:
   - dragonfly
@@ -27,8 +27,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Update dragonfly to 2.2.1.
-    - Update client to 0.2.19.
+    - Fix correct indentation in client-daemonset.yaml hostPath.
 
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/dragonfly/templates/client/client-daemonset.yaml
+++ b/charts/dragonfly/templates/client/client-daemonset.yaml
@@ -189,8 +189,8 @@ spec:
           name: {{ template "dragonfly.client.fullname" . }}
       - name: socket-dir
         hostPath:
-            path: /var/run/dragonfly
-            type: DirectoryOrCreate
+          path: /var/run/dragonfly
+          type: DirectoryOrCreate
       {{- if .Values.client.dfinit.enable }}
       - name: dfinit-config
         configMap:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes updates to the `charts/dragonfly/Chart.yaml` file. The changes involve updating the version of the Dragonfly chart and correcting the annotations related to the client-daemonset.yaml file.

Version update:

* Updated the `version` field from `1.3.15` to `1.3.16` to reflect the latest release.

Annotations correction:

* Modified the `artifacthub.io/changes` annotation to correct the description of changes, specifically fixing the indentation in the `client-daemonset.yaml` file.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
