### PR TITLE
chore: bump client to v0.2.23

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.3.17
+version: 1.3.18
 appVersion: 2.2.1
 keywords:
   - dragonfly
@@ -27,7 +27,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Update client version to v0.2.22.
+    - Update client version to v0.2.23.
 
   artifacthub.io/links: |
     - name: Chart Source
@@ -42,11 +42,11 @@ annotations:
     - name: scheduler
       image: dragonflyoss/scheduler:v2.2.1
     - name: client
-      image: dragonflyoss/client:v0.2.22
+      image: dragonflyoss/client:v0.2.23
     - name: seed-client
-      image: dragonflyoss/client:v0.2.22
+      image: dragonflyoss/client:v0.2.23
     - name: dfinit
-      image: dragonflyoss/dfinit:v0.2.22
+      image: dragonflyoss/dfinit:v0.2.23
 
 dependencies:
   - name: mysql

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -176,7 +176,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.dfinit.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | client.dfinit.image.registry | string | `"docker.io"` | Image registry. |
 | client.dfinit.image.repository | string | `"dragonflyoss/dfinit"` | Image repository. |
-| client.dfinit.image.tag | string | `"v0.2.22"` | Image tag. |
+| client.dfinit.image.tag | string | `"v0.2.23"` | Image tag. |
 | client.enable | bool | `true` | Enable client. |
 | client.extraVolumeMounts | list | `[{"mountPath":"/var/lib/dragonfly/","name":"storage"},{"mountPath":"/var/log/dragonfly/dfdaemon/","name":"logs"}]` | Extra volumeMounts for dfdaemon. |
 | client.extraVolumes | list | `[{"emptyDir":{},"name":"storage"},{"emptyDir":{},"name":"logs"}]` | Extra volumes for dfdaemon. |
@@ -190,7 +190,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | client.image.registry | string | `"docker.io"` | Image registry. |
 | client.image.repository | string | `"dragonflyoss/client"` | Image repository. |
-| client.image.tag | string | `"v0.2.22"` | Image tag. |
+| client.image.tag | string | `"v0.2.23"` | Image tag. |
 | client.initContainer.image.digest | string | `""` | Image digest. |
 | client.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | client.initContainer.image.registry | string | `"docker.io"` | Image registry. |
@@ -476,7 +476,7 @@ helm delete dragonfly --namespace dragonfly-system
 | seedClient.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | seedClient.image.registry | string | `"docker.io"` | Image registry. |
 | seedClient.image.repository | string | `"dragonflyoss/client"` | Image repository. |
-| seedClient.image.tag | string | `"v0.2.22"` | Image tag. |
+| seedClient.image.tag | string | `"v0.2.23"` | Image tag. |
 | seedClient.initContainer.image.digest | string | `""` | Image digest. |
 | seedClient.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | seedClient.initContainer.image.registry | string | `"docker.io"` | Image registry. |

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -688,7 +688,7 @@ seedClient:
     # -- Image repository.
     repository: dragonflyoss/client
     # -- Image tag.
-    tag: v0.2.22
+    tag: v0.2.23
     # -- Image digest.
     digest: ""
     # -- Image pull policy.
@@ -1064,7 +1064,7 @@ client:
     # -- Image repository.
     repository: dragonflyoss/client
     # -- Image tag.
-    tag: v0.2.22
+    tag: v0.2.23
     # -- Image digest.
     digest: ""
     # -- Image pull policy.
@@ -1145,7 +1145,7 @@ client:
       # -- Image repository.
       repository: dragonflyoss/dfinit
       # -- Image tag.
-      tag: v0.2.22
+      tag: v0.2.23
       # -- Image digest.
       digest: ""
       # -- Image pull policy.


### PR DESCRIPTION
This pull request includes several updates to the `dragonfly` Helm chart, focusing on version upgrades for various components. The most important changes include updating the versions of the `dragonfly` chart, client, manager, scheduler, and seed-client images.

Version updates:

* [`charts/dragonfly/Chart.yaml`](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L6-R6): Updated the `dragonfly` chart version from `1.3.16` to `1.3.18` and the client version annotation to `v0.2.23`. [[1]](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L6-R6) [[2]](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L30-R30)
* [`charts/dragonfly/Chart.yaml`](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L41-R49): Updated the `manager` image to `v2.2.2.1`, and the `client`, `seed-client`, and `dfinit` images to `v0.2.23`.
* [`charts/dragonfly/README.md`](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL179-R179): Updated the `dfinit` image tag to `v0.2.23`.
* [`charts/dragonfly/README.md`](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL193-R193): Updated the `client` image tag to `v0.2.23`.
* [`charts/dragonfly/README.md`](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL479-R479): Updated the `seed-client` image tag to `v0.2.23`.
* [`charts/dragonfly/values.yaml`](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL691-R691): Updated the `seed-client`, `client`, and `dfinit` image tags to `v0.2.23`. [[1]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL691-R691) [[2]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL1067-R1067) [[3]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL1148-R1148)<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This pull request includes several updates to the `charts/dragonfly` files, primarily focusing on updating the client version and related image tags.

Version updates:

* [`charts/dragonfly/Chart.yaml`](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L6-R6): Updated the chart version from `1.3.17` to `1.3.18` and the client version in annotations from `v0.2.22` to `v0.2.23`. [[1]](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L6-R6) [[2]](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L30-R30)
* [`charts/dragonfly/Chart.yaml`](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L45-R49): Updated image tags for `client`, `seed-client`, and `dfinit` from `v0.2.22` to `v0.2.23`.

Documentation updates:

* [`charts/dragonfly/README.md`](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL179-R179): Updated image tags for `client.dfinit.image.tag`, `client.image.tag`, and `seedClient.image.tag` from `v0.2.22` to `v0.2.23`. [[1]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL179-R179) [[2]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL193-R193) [[3]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL479-R479)

Configuration updates:

* [`charts/dragonfly/values.yaml`](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL691-R691): Updated image tags for `client`, `seedClient`, and `dfinit` from `v0.2.22` to `v0.2.23`. [[1]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL691-R691) [[2]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL1067-R1067) [[3]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL1148-R1148)