### PR TITLE
feat(externalRedis): add sentinel username and password fields

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.3.21
+version: 1.3.22
 appVersion: 2.2.2
 keywords:
   - dragonfly
@@ -27,8 +27,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Update dragonfly to v2.2.2.
-    - Add updateStrategy for client daemonset.
+    - Add sentinel username and password fields.
 
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -236,6 +236,8 @@ helm delete dragonfly --namespace dragonfly-system
 | externalRedis.db | int | `0` | External redis db. |
 | externalRedis.masterName | string | `""` | External redis sentinel master name. |
 | externalRedis.password | string | `""` | External redis password. |
+| externalRedis.sentinelPassword | string | `""` | External redis sentinel password. |
+| externalRedis.sentinelUsername | string | `""` | External redis sentinel addresses. |
 | externalRedis.username | string | `""` | External redis username. |
 | fullnameOverride | string | `""` | Override dragonfly fullname. |
 | global.imagePullSecrets | list | `[]` | Global Docker registry secret names as an array. |

--- a/charts/dragonfly/templates/manager/manager-configmap.yaml
+++ b/charts/dragonfly/templates/manager/manager-configmap.yaml
@@ -59,6 +59,8 @@ data:
         masterName: {{ .Values.externalRedis.masterName }}
         username: {{ .Values.externalRedis.username }}
         password: {{ .Values.externalRedis.password }}
+        sentinelUsername: {{ .Values.externalRedis.sentinelUsername }}
+        sentinelPassword: {{ .Values.externalRedis.sentinelPassword }}
         db: {{ .Values.externalRedis.db }}
         brokerDB: {{ .Values.externalRedis.brokerDB }}
         backendDB: {{ .Values.externalRedis.backendDB }}

--- a/charts/dragonfly/templates/scheduler/scheduler-configmap.yaml
+++ b/charts/dragonfly/templates/scheduler/scheduler-configmap.yaml
@@ -28,6 +28,8 @@ data:
         masterName: {{ .Values.externalRedis.masterName }}
         username: {{ .Values.externalRedis.username }}
         password: {{ .Values.externalRedis.password }}
+        sentinelUsername: {{ .Values.externalRedis.sentinelUsername }}
+        sentinelPassword: {{ .Values.externalRedis.sentinelPassword }}
         brokerDB: {{ .Values.externalRedis.brokerDB }}
         backendDB: {{ .Values.externalRedis.backendDB }}
         {{- end }}
@@ -58,6 +60,8 @@ data:
         masterName: {{ .Values.externalRedis.masterName }}
         username: {{ .Values.externalRedis.username }}
         password: {{ .Values.externalRedis.password }}
+        sentinelUsername: {{ .Values.externalRedis.sentinelUsername }}
+        sentinelPassword: {{ .Values.externalRedis.sentinelPassword }}
         brokerDB: {{ .Values.externalRedis.brokerDB }}
         backendDB: {{ .Values.externalRedis.backendDB }}
         {{- end }}

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -1556,6 +1556,10 @@ externalRedis:
   username: ""
   # -- External redis password.
   password: ""
+  # -- External redis sentinel addresses.
+  sentinelUsername: "" 
+  # -- External redis sentinel password.
+  sentinelPassword: "" 
   # -- External redis db.
   db: 0
   # -- External redis broker db.

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -1557,9 +1557,9 @@ externalRedis:
   # -- External redis password.
   password: ""
   # -- External redis sentinel addresses.
-  sentinelUsername: "" 
+  sentinelUsername: ""
   # -- External redis sentinel password.
-  sentinelPassword: "" 
+  sentinelPassword: ""
   # -- External redis db.
   db: 0
   # -- External redis broker db.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces updates to the Dragonfly Helm chart, focusing on adding support for Redis Sentinel authentication and updating the chart version. The most significant changes include the addition of new fields for Redis Sentinel credentials, updates to configuration templates, and the version bump in the chart metadata.

### Redis Sentinel Authentication Enhancements:
* Added `sentinelUsername` and `sentinelPassword` fields to `externalRedis` in `values.yaml` to support Redis Sentinel authentication.
* Updated `manager-configmap.yaml` and `scheduler-configmap.yaml` to include the new `sentinelUsername` and `sentinelPassword` fields in the configuration templates. [[1]](diffhunk://#diff-951b3103fd9d8a55ee0c45f002b625eeffcad463a83a5a3bdc0ca6c398c5ec80R62-R63) [[2]](diffhunk://#diff-c05eaf561a55a7c637819cee107deb97d578c5304e869f13cc13224341ebd333R31-R32) [[3]](diffhunk://#diff-c05eaf561a55a7c637819cee107deb97d578c5304e869f13cc13224341ebd333R63-R64)
* Documented the new Redis Sentinel fields (`sentinelUsername` and `sentinelPassword`) in the `README.md` file.

### Chart Metadata Updates:
* Bumped the chart version from `1.3.21` to `1.3.22` in `Chart.yaml`.
* Updated the `artifacthub.io/changes` annotation in `Chart.yaml` to include the addition of the Redis Sentinel username and password fields.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
