### PR TITLE
feat: change peerTTL from 48h to 720h in scheduler

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.3.34
+version: 1.3.35
 appVersion: 2.2.4-beta.1
 keywords:
   - dragonfly
@@ -27,7 +27,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Add headers for tracing in seed client and client.
+    - Change peerTTL from 48h to 720h in scheduler.
 
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -362,7 +362,7 @@ helm delete dragonfly --namespace dragonfly-system
 | scheduler.config.scheduler.gc.hostGCInterval | string | `"5m"` | hostGCInterval is the interval of host gc. |
 | scheduler.config.scheduler.gc.hostTTL | string | `"1h"` | hostTTL is time to live of host. If host announces message to scheduler, then HostTTl will be reset. |
 | scheduler.config.scheduler.gc.peerGCInterval | string | `"5m"` | peerGCInterval is the interval of peer gc. |
-| scheduler.config.scheduler.gc.peerTTL | string | `"48h"` | peerTTL is the ttl of peer. If the peer has been downloaded by other peers, then PeerTTL will be reset. |
+| scheduler.config.scheduler.gc.peerTTL | string | `"720h"` | peerTTL is the ttl of peer. If the peer has been downloaded by other peers, then PeerTTL will be reset. |
 | scheduler.config.scheduler.gc.pieceDownloadTimeout | string | `"30m"` | pieceDownloadTimeout is the timeout of downloading piece. |
 | scheduler.config.scheduler.gc.taskGCInterval | string | `"30m"` | taskGCInterval is the interval of task gc. If all the peers have been reclaimed in the task, then the task will also be reclaimed. |
 | scheduler.config.scheduler.retryBackToSourceLimit | int | `3` | retryBackToSourceLimit reaches the limit, then the peer back-to-source. |

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -442,7 +442,7 @@ scheduler:
         peerGCInterval: 5m
         # -- peerTTL is the ttl of peer. If the peer has been downloaded by other peers,
         # then PeerTTL will be reset.
-        peerTTL: 48h
+        peerTTL: 720h
         # -- taskGCInterval is the interval of task gc. If all the peers have been reclaimed in the task,
         # then the task will also be reclaimed.
         taskGCInterval: 30m


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the Dragonfly Helm chart to include a version bump and modifies the scheduler's `peerTTL` configuration to significantly extend its time-to-live. Below is a summary of the most important changes grouped by theme.

### Version Update:
* [`charts/dragonfly/Chart.yaml`](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L6-R6): Updated the chart version from `1.3.34` to `1.3.35`.

### Scheduler Configuration Changes:
* [`charts/dragonfly/Chart.yaml`](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L30-R30): Updated the `artifacthub.io/changes` annotation to reflect the change of `peerTTL` from `48h` to `720h`.
* [`charts/dragonfly/README.md`](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL365-R365): Updated the `peerTTL` description in the scheduler configuration table to reflect the new value of `720h`.
* [`charts/dragonfly/values.yaml`](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL445-R445): Changed the `peerTTL` value in the scheduler configuration from `48h` to `720h`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
