### PR TITLE
feat: update Dragonfly Helm chart to v1.3.37 with OTLP HTTP/GRPC support

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,8 +3,8 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.3.36
-appVersion: 2.2.4-beta.1
+version: 1.3.37
+appVersion: 2.2.4-rc.0
 keywords:
   - dragonfly
   - d7y
@@ -27,7 +27,9 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Change peerTTL from 48h to 720h in scheduler.
+    - Bump dragonfly to v2.2.4-rc.0.
+    - Bump client to v0.2.37.
+    - Add http and grpc support for otel.
 
   artifacthub.io/links: |
     - name: Chart Source
@@ -38,15 +40,15 @@ annotations:
       url: https://github.com/dragonflyoss/client
   artifacthub.io/images: |
     - name: manager
-      image: dragonflyoss/manager:v2.2.4-beta.1
+      image: dragonflyoss/manager:v2.2.4-rc.0
     - name: scheduler
-      image: dragonflyoss/scheduler:v2.2.4-beta.1
+      image: dragonflyoss/scheduler:v2.2.4-rc.0
     - name: client
-      image: dragonflyoss/client:v0.2.35
+      image: dragonflyoss/client:v0.2.37
     - name: seed-client
-      image: dragonflyoss/client:v0.2.35
+      image: dragonflyoss/client:v0.2.37
     - name: dfinit
-      image: dragonflyoss/dfinit:v0.2.35
+      image: dragonflyoss/dfinit:v0.2.37
 
 dependencies:
   - name: mysql

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -177,7 +177,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.dfinit.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | client.dfinit.image.registry | string | `"docker.io"` | Image registry. |
 | client.dfinit.image.repository | string | `"dragonflyoss/dfinit"` | Image repository. |
-| client.dfinit.image.tag | string | `"v0.2.35"` | Image tag. |
+| client.dfinit.image.tag | string | `"v0.2.37"` | Image tag. |
 | client.dfinit.restartContainerRuntime | bool | `true` | restartContainerRuntime indicates whether to restart container runtime when dfinit is enabled. it should be set to true when your first install dragonfly. If non-hot load configuration changes are made, the container runtime needs to be restarted. |
 | client.enable | bool | `true` | Enable client. |
 | client.extraVolumeMounts | list | `[{"mountPath":"/var/lib/dragonfly/","name":"storage"},{"mountPath":"/var/log/dragonfly/dfdaemon/","name":"logs"}]` | Extra volumeMounts for dfdaemon. |
@@ -192,7 +192,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | client.image.registry | string | `"docker.io"` | Image registry. |
 | client.image.repository | string | `"dragonflyoss/client"` | Image repository. |
-| client.image.tag | string | `"v0.2.35"` | Image tag. |
+| client.image.tag | string | `"v0.2.37"` | Image tag. |
 | client.initContainer.image.digest | string | `""` | Image digest. |
 | client.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | client.initContainer.image.registry | string | `"docker.io"` | Image registry. |
@@ -275,8 +275,6 @@ helm delete dragonfly --namespace dragonfly-system
 | manager.config.server.rest.tls.cert | string | `""` | Certificate file path. |
 | manager.config.server.rest.tls.key | string | `""` | Key file path. |
 | manager.config.server.workHome | string | `""` | Work directory. |
-| manager.config.tracing.addr | string | `""` |  |
-| manager.config.tracing.headers | object | `{}` |  |
 | manager.config.verbose | bool | `true` | Whether to enable debug level logger and enable pprof. |
 | manager.deploymentAnnotations | object | `{}` | Deployment annotations. |
 | manager.enable | bool | `true` | Enable manager. |
@@ -291,7 +289,7 @@ helm delete dragonfly --namespace dragonfly-system
 | manager.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | manager.image.registry | string | `"docker.io"` | Image registry. |
 | manager.image.repository | string | `"dragonflyoss/manager"` | Image repository. |
-| manager.image.tag | string | `"v2.2.4-beta.1"` | Image tag. |
+| manager.image.tag | string | `"v2.2.4-rc.0"` | Image tag. |
 | manager.ingress.annotations | object | `{}` | Ingress annotations. |
 | manager.ingress.className | string | `""` | Ingress class name. Requirement: kubernetes >=1.18. |
 | manager.ingress.enable | bool | `false` | Enable ingress. |
@@ -378,8 +376,6 @@ helm delete dragonfly --namespace dragonfly-system
 | scheduler.config.server.pluginDir | string | `""` | Plugin directory. |
 | scheduler.config.server.port | int | `8002` | Server port. |
 | scheduler.config.server.workHome | string | `""` | Work directory. |
-| scheduler.config.tracing.addr | string | `""` |  |
-| scheduler.config.tracing.headers | object | `{}` |  |
 | scheduler.config.verbose | bool | `true` | Whether to enable debug level logger and enable pprof. |
 | scheduler.containerPort | int | `8002` | Pod containerPort. |
 | scheduler.enable | bool | `true` | Enable scheduler. |
@@ -393,7 +389,7 @@ helm delete dragonfly --namespace dragonfly-system
 | scheduler.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | scheduler.image.registry | string | `"docker.io"` | Image registry. |
 | scheduler.image.repository | string | `"dragonflyoss/scheduler"` | Image repository. |
-| scheduler.image.tag | string | `"v2.2.4-beta.1"` | Image tag. |
+| scheduler.image.tag | string | `"v2.2.4-rc.0"` | Image tag. |
 | scheduler.initContainer.image.digest | string | `""` | Image digest. |
 | scheduler.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | scheduler.initContainer.image.registry | string | `"docker.io"` | Image registry. |
@@ -481,7 +477,7 @@ helm delete dragonfly --namespace dragonfly-system
 | seedClient.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | seedClient.image.registry | string | `"docker.io"` | Image registry. |
 | seedClient.image.repository | string | `"dragonflyoss/client"` | Image repository. |
-| seedClient.image.tag | string | `"v0.2.35"` | Image tag. |
+| seedClient.image.tag | string | `"v0.2.37"` | Image tag. |
 | seedClient.initContainer.image.digest | string | `""` | Image digest. |
 | seedClient.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | seedClient.initContainer.image.registry | string | `"docker.io"` | Image registry. |

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -39,7 +39,7 @@ manager:
     # -- Image repository.
     repository: dragonflyoss/manager
     # -- Image tag.
-    tag: v2.2.4-beta.1
+    tag: v2.2.4-rc.0
     # -- Image digest.
     digest: ""
     # -- Image pull policy.
@@ -221,11 +221,16 @@ manager:
     # -- Listen port for pprof, only valid when the verbose option is true
     # default is -1. If it is 0, pprof will use a random port.
     pprofPort: -1
-    tracing:
-      # - Jaeger endpoint url, like: jaeger.dragonfly.svc:4317.
-      addr: ""
-      # - Headers is the grpc's headers to send with tracing log.
-      headers: {}
+    # # tracing is the tracing configuration for dfdaemon.
+    # tracing:
+    #   # Protocol specifies the communication protocol for the tracing server.
+    #   # Supported values: "http", "https", "grpc" (default: None).
+    #   # This determines how tracing logs are transmitted to the server.
+    #   protocol: grpc
+    #   # endpoint is the endpoint to report tracing log, example: "localhost:4317".
+    #   endpoint: localhost:4317
+    #   # headers is the grpc's headers to send with tracing log.
+    #   headers: {}
   metrics:
     # -- Enable manager metrics.
     enable: true
@@ -315,7 +320,7 @@ scheduler:
     # -- Image repository.
     repository: dragonflyoss/scheduler
     # -- Image tag.
-    tag: v2.2.4-beta.1
+    tag: v2.2.4-rc.0
     # -- Image digest.
     digest: ""
     # -- Image pull policy.
@@ -496,11 +501,16 @@ scheduler:
     # -- Listen port for pprof, only valid when the verbose option is true.
     # default is -1. If it is 0, pprof will use a random port.
     pprofPort: -1
-    tracing:
-      # - Jaeger endpoint url, like: jaeger.dragonfly.svc:4317.
-      addr: ""
-      # - Headers is the grpc's headers to send with tracing log.
-      headers: {}
+    # # tracing is the tracing configuration for dfdaemon.
+    # tracing:
+    #   # Protocol specifies the communication protocol for the tracing server.
+    #   # Supported values: "http", "https", "grpc" (default: None).
+    #   # This determines how tracing logs are transmitted to the server.
+    #   protocol: grpc
+    #   # endpoint is the endpoint to report tracing log, example: "localhost:4317".
+    #   endpoint: localhost:4317
+    #   # headers is the grpc's headers to send with tracing log.
+    #   headers: {}
   metrics:
     # -- Enable scheduler metrics.
     enable: true
@@ -688,7 +698,7 @@ seedClient:
     # -- Image repository.
     repository: dragonflyoss/client
     # -- Image tag.
-    tag: v0.2.35
+    tag: v0.2.37
     # -- Image digest.
     digest: ""
     # -- Image pull policy.
@@ -1032,10 +1042,14 @@ seedClient:
       # ip: ""
     # # tracing is the tracing configuration for dfdaemon.
     # tracing:
-      # # addr is the address to report tracing log, like jaeger.dragonfly.svc:4317.
-      # addr: ""
-      # # Headers is the grpc's headers to send with tracing log.
-      # headers: {}
+    #   # Protocol specifies the communication protocol for the tracing server.
+    #   # Supported values: "http", "https", "grpc" (default: None).
+    #   # This determines how tracing logs are transmitted to the server.
+    #   protocol: grpc
+    #   # endpoint is the endpoint to report tracing log, example: "localhost:4317".
+    #   endpoint: localhost:4317
+    #   # headers is the grpc's headers to send with tracing log.
+    #   headers: {}
   metrics:
     # -- Enable seed client metrics.
     enable: true
@@ -1107,7 +1121,7 @@ client:
     # -- Image repository.
     repository: dragonflyoss/client
     # -- Image tag.
-    tag: v0.2.35
+    tag: v0.2.37
     # -- Image digest.
     digest: ""
     # -- Image pull policy.
@@ -1194,7 +1208,7 @@ client:
       # -- Image repository.
       repository: dragonflyoss/dfinit
       # -- Image tag.
-      tag: v0.2.35
+      tag: v0.2.37
       # -- Image digest.
       digest: ""
       # -- Image pull policy.
@@ -1516,10 +1530,14 @@ client:
       # ip: ""
     # # tracing is the tracing configuration for dfdaemon.
     # tracing:
-      # # addr is the address to report tracing log, like jaeger.dragonfly.svc:4317.
-      # addr: ""
-      # # Headers is the grpc's headers to send with tracing log.
-      # headers: {}
+    #   # Protocol specifies the communication protocol for the tracing server.
+    #   # Supported values: "http", "https", "grpc" (default: None).
+    #   # This determines how tracing logs are transmitted to the server.
+    #   protocol: grpc
+    #   # endpoint is the endpoint to report tracing log, example: "localhost:4317".
+    #   endpoint: localhost:4317
+    #   # headers is the grpc's headers to send with tracing log.
+    #   headers: {}
   metrics:
     # -- Enable client metrics.
     enable: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the Dragonfly Helm chart to include new versions of its components and introduces support for OpenTelemetry (OTel) tracing protocols. The most significant changes involve version bumps for various components and the addition of tracing configurations.

### Version Updates:
* Updated `version` to `1.3.37` and `appVersion` to `2.2.4-rc.0` in `charts/dragonfly/Chart.yaml`.
* Updated image tags for `manager`, `scheduler`, `client`, `seed-client`, and `dfinit` components to align with the new release versions in `charts/dragonfly/Chart.yaml`, `charts/dragonfly/README.md`, and `charts/dragonfly/values.yaml`. [[1]](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L41-R51) [[2]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL180-R180) [[3]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL195-R195) [[4]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL294-R292) [[5]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL396-R392) [[6]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL484-R480) [[7]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL42-R42) [[8]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL318-R323) [[9]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL691-R701) [[10]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL1110-R1124) [[11]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL1197-R1211)

### OpenTelemetry (OTel) Support:
* Added support for HTTP and gRPC protocols for OpenTelemetry tracing in `charts/dragonfly/Chart.yaml`.
* Introduced detailed tracing configuration options for `manager`, `scheduler`, `seedClient`, and `client` components in `charts/dragonfly/values.yaml`. This includes specifying protocols (`http`, `https`, `grpc`), endpoints, and headers for tracing logs. [[1]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL224-R233) [[2]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL499-R513) [[3]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL1035-R1051) [[4]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL1519-R1539)

### Cleanup:
* Removed unused tracing configuration fields (`addr` and `headers`) from `charts/dragonfly/README.md` for the `manager` and `scheduler` components. [[1]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL278-L279) [[2]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL381-L382)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
