### PR TITLE
feat: Added collectedPieceTimeout option for dfdaemon and seedClient (default: 10s)

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.3.39
+version: 1.3.40
 appVersion: 2.2.4-rc.0
 keywords:
   - dragonfly
@@ -27,7 +27,10 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Bump client to v0.2.38.
+    - Add logLevel option for manager and scheduler.
+    - Remove verbose option for manager and scheduler.
+    - Add collectedPieceTimeout option for dfdaemon.
+
 
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -129,6 +129,7 @@ helm delete dragonfly --namespace dragonfly-system
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | client.config.console | bool | `true` | console prints log. |
+| client.config.download.collectedPieceTimeout | string | `"10s"` | collected_piece_timeout is the timeout for collecting one piece from the parent in the stream. |
 | client.config.download.concurrentPieceCount | int | `8` | concurrentPieceCount is the number of concurrent pieces to download. |
 | client.config.download.pieceTimeout | string | `"120s"` | pieceTimeout is the timeout for downloading a piece from source. |
 | client.config.download.rateLimit | string | `"50GiB"` | rateLimit is the default rate limit of the download speed in GiB/Mib/Kib per second, default is 50GiB/s. |
@@ -267,15 +268,15 @@ helm delete dragonfly --namespace dragonfly-system
 | manager.config.job.syncPeers | object | `{"interval":"24h","timeout":"10m"}` | Sync peers configuration. |
 | manager.config.job.syncPeers.interval | string | `"24h"` | interval is the interval for syncing all peers information from the scheduler and display peers information in the manager console. |
 | manager.config.job.syncPeers.timeout | string | `"10m"` | timeout is the timeout for syncing peers information from the single scheduler. |
-| manager.config.pprofPort | int | `-1` | Listen port for pprof, only valid when the verbose option is true default is -1. If it is 0, pprof will use a random port. |
+| manager.config.pprofPort | int | `-1` | Listen port for pprof, default is -1 (meaning disabled). |
 | manager.config.server.cacheDir | string | `""` | Dynconfig cache directory. |
 | manager.config.server.grpc.advertiseIP | string | `""` | GRPC advertise ip. |
 | manager.config.server.logDir | string | `""` | Log directory. |
+| manager.config.server.logLevel | string | `"info"` | logLevel specifies the logging level for the manager. Default: "info" Supported values: "debug", "info", "warn", "error", "panic", "fatal" |
 | manager.config.server.pluginDir | string | `""` | Plugin directory. |
 | manager.config.server.rest.tls.cert | string | `""` | Certificate file path. |
 | manager.config.server.rest.tls.key | string | `""` | Key file path. |
 | manager.config.server.workHome | string | `""` | Work directory. |
-| manager.config.verbose | bool | `true` | Whether to enable debug level logger and enable pprof. |
 | manager.deploymentAnnotations | object | `{}` | Deployment annotations. |
 | manager.enable | bool | `true` | Enable manager. |
 | manager.extraVolumeMounts | list | `[{"mountPath":"/var/log/dragonfly/manager","name":"logs"}]` | Extra volumeMounts for manager. |
@@ -354,7 +355,7 @@ helm delete dragonfly --namespace dragonfly-system
 | scheduler.config.host.location | string | `""` | Location is the location of scheduler instance. |
 | scheduler.config.manager.keepAlive.interval | string | `"5s"` | Manager keepalive interval. |
 | scheduler.config.manager.schedulerClusterID | int | `1` | Associated scheduler cluster id. |
-| scheduler.config.pprofPort | int | `-1` | Listen port for pprof, only valid when the verbose option is true. default is -1. If it is 0, pprof will use a random port. |
+| scheduler.config.pprofPort | int | `-1` | Listen port for pprof, default is -1 (meaning disabled). |
 | scheduler.config.scheduler.algorithm | string | `"default"` | Algorithm configuration to use different scheduling algorithms, default configuration supports "default", "ml" and "nt". "default" is the rule-based scheduling algorithm, "ml" is the machine learning scheduling algorithm. It also supports user plugin extension, the algorithm value is "plugin", and the compiled `d7y-scheduler-plugin-evaluator.so` file is added to the dragonfly working directory plugins. |
 | scheduler.config.scheduler.backToSourceCount | int | `200` | backToSourceCount is single task allows the peer to back-to-source count. |
 | scheduler.config.scheduler.gc.hostGCInterval | string | `"5m"` | hostGCInterval is the interval of host gc. |
@@ -373,10 +374,10 @@ helm delete dragonfly --namespace dragonfly-system
 | scheduler.config.server.dataDir | string | `""` | Storage directory. |
 | scheduler.config.server.listenIP | string | `"0.0.0.0"` | Listen ip. |
 | scheduler.config.server.logDir | string | `""` | Log directory. |
+| scheduler.config.server.logLevel | string | `"info"` | logLevel specifies the logging level for the scheduler. Default: "info" Supported values: "debug", "info", "warn", "error", "panic", "fatal" |
 | scheduler.config.server.pluginDir | string | `""` | Plugin directory. |
 | scheduler.config.server.port | int | `8002` | Server port. |
 | scheduler.config.server.workHome | string | `""` | Work directory. |
-| scheduler.config.verbose | bool | `true` | Whether to enable debug level logger and enable pprof. |
 | scheduler.containerPort | int | `8002` | Pod containerPort. |
 | scheduler.enable | bool | `true` | Enable scheduler. |
 | scheduler.extraVolumeMounts | list | `[{"mountPath":"/var/log/dragonfly/scheduler","name":"logs"}]` | Extra volumeMounts for scheduler. |
@@ -426,6 +427,7 @@ helm delete dragonfly --namespace dragonfly-system
 | scheduler.tolerations | list | `[]` | List of node taints to tolerate. |
 | scheduler.updateStrategy | object | `{}` | Update strategy for replicas. |
 | seedClient.config.console | bool | `true` | console prints log. |
+| seedClient.config.download.collectedPieceTimeout | string | `"10s"` | collected_piece_timeout is the timeout for collecting one piece from the parent in the stream. |
 | seedClient.config.download.concurrentPieceCount | int | `16` | concurrentPieceCount is the number of concurrent pieces to download. |
 | seedClient.config.download.pieceTimeout | string | `"120s"` | pieceTimeout is the timeout for downloading a piece from source. |
 | seedClient.config.download.rateLimit | string | `"50GiB"` | rateLimit is the default rate limit of the download speed in GiB/Mib/Kib per second, default is 50GiB/s. |

--- a/charts/dragonfly/templates/manager/manager-configmap.yaml
+++ b/charts/dragonfly/templates/manager/manager-configmap.yaml
@@ -25,6 +25,7 @@ data:
           start: {{ .Values.manager.grpcPort }}
           end: {{ .Values.manager.grpcPort }}
       workHome: {{ .Values.manager.config.server.workHome }}
+      logLevel: {{ .Values.manager.config.server.logLevel }}
       logDir: {{ .Values.manager.config.server.logDir }}
       cacheDir: {{ .Values.manager.config.server.cacheDir }}
       pluginDir: {{ .Values.manager.config.server.pluginDir }}
@@ -74,10 +75,7 @@ data:
       enable: {{ .Values.manager.metrics.enable }}
       addr: ":8000"
     console: {{ .Values.manager.config.console }}
-    verbose: {{ .Values.manager.config.verbose }}
-    {{- if .Values.manager.config.verbose }}
-    pprof-port: {{ .Values.manager.config.pprofPort }}
-    {{- end }}
+    pprofPort: {{ .Values.manager.config.pprofPort }}
     tracing:
 {{ toYaml .Values.manager.config.tracing | indent 6 }}
 {{- end }}

--- a/charts/dragonfly/templates/scheduler/scheduler-configmap.yaml
+++ b/charts/dragonfly/templates/scheduler/scheduler-configmap.yaml
@@ -73,10 +73,7 @@ data:
       addr: ":8000"
       enableHost: {{ .Values.scheduler.metrics.enableHost }}
     console: {{ .Values.scheduler.config.console }}
-    verbose: {{ .Values.scheduler.config.verbose }}
-    {{- if .Values.scheduler.config.verbose }}
-    pprof-port: {{ .Values.scheduler.config.pprofPort }}
-    {{- end }}
+    pprofPort: {{ .Values.scheduler.config.pprofPort }}
     tracing:
 {{ toYaml .Values.scheduler.config.tracing | indent 6 }}
 {{- end }}

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -153,6 +153,10 @@ manager:
           key: ""
       # -- Work directory.
       workHome: ""
+      # -- logLevel specifies the logging level for the manager.
+      # Default: "info"
+      # Supported values: "debug", "info", "warn", "error", "panic", "fatal"
+      logLevel: "info"
       # -- Log directory.
       logDir: ""
       # -- Dynconfig cache directory.
@@ -216,10 +220,7 @@ manager:
         # caCert: ''
     # -- Console shows log on console.
     console: true
-    # -- Whether to enable debug level logger and enable pprof.
-    verbose: true
-    # -- Listen port for pprof, only valid when the verbose option is true
-    # default is -1. If it is 0, pprof will use a random port.
+    # -- Listen port for pprof, default is -1 (meaning disabled).
     pprofPort: -1
     # # tracing is the tracing configuration for dfdaemon.
     # tracing:
@@ -416,6 +417,10 @@ scheduler:
     #
       # -- Work directory.
       workHome: ""
+      # -- logLevel specifies the logging level for the scheduler.
+      # Default: "info"
+      # Supported values: "debug", "info", "warn", "error", "panic", "fatal"
+      logLevel: "info"
       # -- Log directory.
       logDir: ""
       # -- Dynconfig cache directory.
@@ -496,10 +501,7 @@ scheduler:
     #   key: /etc/ssl/private/client.pem
     # -- Console shows log on console.
     console: true
-    # -- Whether to enable debug level logger and enable pprof.
-    verbose: true
-    # -- Listen port for pprof, only valid when the verbose option is true.
-    # default is -1. If it is 0, pprof will use a random port.
+    # -- Listen port for pprof, default is -1 (meaning disabled).
     pprofPort: -1
     # # tracing is the tracing configuration for dfdaemon.
     # tracing:
@@ -820,6 +822,8 @@ seedClient:
       rateLimit: 50GiB
       # --  pieceTimeout is the timeout for downloading a piece from source.
       pieceTimeout: 120s
+      # -- collected_piece_timeout is the timeout for collecting one piece from the parent in the stream.
+      collectedPieceTimeout: 10s
       # -- concurrentPieceCount is the number of concurrent pieces to download.
       concurrentPieceCount: 16
     upload:
@@ -1313,6 +1317,8 @@ client:
       rateLimit: 50GiB
       # --  pieceTimeout is the timeout for downloading a piece from source.
       pieceTimeout: 120s
+      # -- collected_piece_timeout is the timeout for collecting one piece from the parent in the stream.
+      collectedPieceTimeout: 10s
       # -- concurrentPieceCount is the number of concurrent pieces to download.
       concurrentPieceCount: 8
     upload:


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces several updates to the Dragonfly Helm chart, including new configuration options, cleanup of deprecated settings, and documentation updates. The changes focus on enhancing configurability, improving logging granularity, and streamlining options for the manager, scheduler, and client components.

### Configuration Updates

* Added `logLevel` configuration for both `manager` and `scheduler` to specify logging levels such as "debug", "info", "warn", etc. [[1]](diffhunk://#diff-951b3103fd9d8a55ee0c45f002b625eeffcad463a83a5a3bdc0ca6c398c5ec80R28) [[2]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bR156-R159) [[3]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bR420-R423)
* Introduced `collectedPieceTimeout` for `client` and `seedClient`, which defines the timeout for collecting a piece from the parent in the stream. [[1]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR132) [[2]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR430) [[3]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bR1320-R1321) [[4]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bR825-R826)

### Cleanup of Deprecated Options

* Removed the `verbose` option from both `manager` and `scheduler` configurations, simplifying debug-related settings. [[1]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL219-R223) [[2]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL499-R504) [[3]](diffhunk://#diff-951b3103fd9d8a55ee0c45f002b625eeffcad463a83a5a3bdc0ca6c398c5ec80L77-R78) [[4]](diffhunk://#diff-c05eaf561a55a7c637819cee107deb97d578c5304e869f13cc13224341ebd333L76-R76)

### Documentation Enhancements

* Updated the `README.md` to reflect new configuration options (`logLevel`, `collectedPieceTimeout`) and removed references to deprecated settings (`verbose`). [[1]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL270-L278) [[2]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL357-R358) [[3]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR377-L379)

### Version Bump

* Incremented chart version to `1.3.40` to reflect the updates.

### ArtifactHub Annotations

* Updated `artifacthub.io/changes` to include details about added and removed options.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
