### PR TITLE
chore: bump client to v1.0.1

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.4.0
+version: 1.4.1
 appVersion: 2.3.0
 keywords:
   - dragonfly
@@ -27,8 +27,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Bump Dragonfly to v2.3.0.
-    - Bump Client to v1.0.0.
+    - Bump Client to v1.0.1.
 
   artifacthub.io/links: |
     - name: Chart Source
@@ -43,11 +42,11 @@ annotations:
     - name: scheduler
       image: dragonflyoss/scheduler:v2.3.0
     - name: client
-      image: dragonflyoss/client:v1.0.0
+      image: dragonflyoss/client:v1.0.1
     - name: seed-client
-      image: dragonflyoss/client:v1.0.0
+      image: dragonflyoss/client:v1.0.1
     - name: dfinit
-      image: dragonflyoss/dfinit:v1.0.0
+      image: dragonflyoss/dfinit:v1.0.1
 
 dependencies:
   - name: mysql

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -131,7 +131,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.config.console | bool | `true` | console prints log. |
 | client.config.download.collectedPieceTimeout | string | `"10s"` | collected_piece_timeout is the timeout for collecting one piece from the parent in the stream. |
 | client.config.download.concurrentPieceCount | int | `8` | concurrentPieceCount is the number of concurrent pieces to download. |
-| client.config.download.pieceTimeout | string | `"120s"` | pieceTimeout is the timeout for downloading a piece from source. |
+| client.config.download.pieceTimeout | string | `"40s"` | pieceTimeout is the timeout for downloading a piece from source. |
 | client.config.download.rateLimit | string | `"50GiB"` | rateLimit is the default rate limit of the download speed in GiB/Mib/Kib per second, default is 50GiB/s. |
 | client.config.download.server.requestRateLimit | int | `4000` | request_rate_limit is the rate limit of the download request in the download grpc server, default is 4000 req/s. |
 | client.config.download.server.socketPath | string | `"/var/run/dragonfly/dfdaemon.sock"` | socketPath is the unix socket path for dfdaemon GRPC service. |
@@ -163,7 +163,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.config.storage.keep | bool | `true` | keep indicates whether keep the task's metadata and content when the dfdaemon restarts. |
 | client.config.storage.readBufferSize | int | `4194304` | readBufferSize is the buffer size for reading piece from disk, default is 4MiB. |
 | client.config.storage.writeBufferSize | int | `4194304` | writeBufferSize is the buffer size for writing piece to disk, default is 4MiB. |
-| client.config.storage.writePieceTimeout | string | `"90s"` | writePieceTimeout is the timeout for writing a piece to storage(e.g., disk or cache). |
+| client.config.storage.writePieceTimeout | string | `"30s"` | writePieceTimeout is the timeout for writing a piece to storage(e.g., disk or cache). |
 | client.config.upload.disableShared | bool | `false` | disableShared indicates whether disable to share data with other peers. |
 | client.config.upload.rateLimit | string | `"50GiB"` | rateLimit is the default rate limit of the upload speed in GiB/Mib/Kib per second, default is 50GiB/s. |
 | client.config.upload.server.port | int | `4000` | port is the port to the grpc server. |
@@ -178,7 +178,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.dfinit.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | client.dfinit.image.registry | string | `"docker.io"` | Image registry. |
 | client.dfinit.image.repository | string | `"dragonflyoss/dfinit"` | Image repository. |
-| client.dfinit.image.tag | string | `"v1.0.0"` | Image tag. |
+| client.dfinit.image.tag | string | `"v1.0.1"` | Image tag. |
 | client.dfinit.restartContainerRuntime | bool | `true` | restartContainerRuntime indicates whether to restart container runtime when dfinit is enabled. it should be set to true when your first install dragonfly. If non-hot load configuration changes are made, the container runtime needs to be restarted. |
 | client.enable | bool | `true` | Enable client. |
 | client.extraVolumeMounts | list | `[{"mountPath":"/var/lib/dragonfly/","name":"storage"},{"mountPath":"/var/log/dragonfly/dfdaemon/","name":"logs"}]` | Extra volumeMounts for dfdaemon. |
@@ -193,7 +193,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | client.image.registry | string | `"docker.io"` | Image registry. |
 | client.image.repository | string | `"dragonflyoss/client"` | Image repository. |
-| client.image.tag | string | `"v1.0.0"` | Image tag. |
+| client.image.tag | string | `"v1.0.1"` | Image tag. |
 | client.initContainer.image.digest | string | `""` | Image digest. |
 | client.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | client.initContainer.image.registry | string | `"docker.io"` | Image registry. |
@@ -429,7 +429,7 @@ helm delete dragonfly --namespace dragonfly-system
 | seedClient.config.console | bool | `true` | console prints log. |
 | seedClient.config.download.collectedPieceTimeout | string | `"10s"` | collected_piece_timeout is the timeout for collecting one piece from the parent in the stream. |
 | seedClient.config.download.concurrentPieceCount | int | `16` | concurrentPieceCount is the number of concurrent pieces to download. |
-| seedClient.config.download.pieceTimeout | string | `"120s"` | pieceTimeout is the timeout for downloading a piece from source. |
+| seedClient.config.download.pieceTimeout | string | `"40s"` | pieceTimeout is the timeout for downloading a piece from source. |
 | seedClient.config.download.rateLimit | string | `"50GiB"` | rateLimit is the default rate limit of the download speed in GiB/Mib/Kib per second, default is 50GiB/s. |
 | seedClient.config.download.server.requestRateLimit | int | `4000` | request_rate_limit is the rate limit of the download request in the download grpc server, default is 4000 req/s. |
 | seedClient.config.download.server.socketPath | string | `"/var/run/dragonfly/dfdaemon.sock"` | socketPath is the unix socket path for dfdaemon GRPC service. |
@@ -464,7 +464,7 @@ helm delete dragonfly --namespace dragonfly-system
 | seedClient.config.storage.keep | bool | `true` | keep indicates whether keep the task's metadata and content when the dfdaemon restarts. |
 | seedClient.config.storage.readBufferSize | int | `4194304` | readBufferSize is the buffer size for reading piece from disk, default is 4MiB. |
 | seedClient.config.storage.writeBufferSize | int | `4194304` | writeBufferSize is the buffer size for writing piece to disk, default is 4MiB. |
-| seedClient.config.storage.writePieceTimeout | string | `"90s"` | writePieceTimeout is the timeout for writing a piece to storage(e.g., disk or cache). |
+| seedClient.config.storage.writePieceTimeout | string | `"30s"` | writePieceTimeout is the timeout for writing a piece to storage(e.g., disk or cache). |
 | seedClient.config.upload.rateLimit | string | `"50GiB"` | rateLimit is the default rate limit of the upload speed in GiB/Mib/Kib per second, default is 50GiB/s. |
 | seedClient.config.upload.server.port | int | `4000` | port is the port to the grpc server. |
 | seedClient.config.upload.server.requestRateLimit | int | `4000` | request_rate_limit is the rate limit of the upload request in the upload grpc server, default is 4000 req/s. |
@@ -479,7 +479,7 @@ helm delete dragonfly --namespace dragonfly-system
 | seedClient.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | seedClient.image.registry | string | `"docker.io"` | Image registry. |
 | seedClient.image.repository | string | `"dragonflyoss/client"` | Image repository. |
-| seedClient.image.tag | string | `"v1.0.0"` | Image tag. |
+| seedClient.image.tag | string | `"v1.0.1"` | Image tag. |
 | seedClient.initContainer.image.digest | string | `""` | Image digest. |
 | seedClient.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | seedClient.initContainer.image.registry | string | `"docker.io"` | Image registry. |

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -700,7 +700,7 @@ seedClient:
     # -- Image repository.
     repository: dragonflyoss/client
     # -- Image tag.
-    tag: v1.0.0
+    tag: v1.0.1
     # -- Image digest.
     digest: ""
     # -- Image pull policy.
@@ -821,7 +821,7 @@ seedClient:
       # -- rateLimit is the default rate limit of the download speed in GiB/Mib/Kib per second, default is 50GiB/s.
       rateLimit: 50GiB
       # --  pieceTimeout is the timeout for downloading a piece from source.
-      pieceTimeout: 120s
+      pieceTimeout: 40s
       # -- collected_piece_timeout is the timeout for collecting one piece from the parent in the stream.
       collectedPieceTimeout: 10s
       # -- concurrentPieceCount is the number of concurrent pieces to download.
@@ -925,7 +925,7 @@ seedClient:
       # -- readBufferSize is the buffer size for reading piece from disk, default is 4MiB.
       readBufferSize: 4194304
       # -- writePieceTimeout is the timeout for writing a piece to storage(e.g., disk or cache).
-      writePieceTimeout: 90s
+      writePieceTimeout: 30s
     gc:
       # -- interval is the interval to do gc.
       interval: 900s
@@ -1125,7 +1125,7 @@ client:
     # -- Image repository.
     repository: dragonflyoss/client
     # -- Image tag.
-    tag: v1.0.0
+    tag: v1.0.1
     # -- Image digest.
     digest: ""
     # -- Image pull policy.
@@ -1212,7 +1212,7 @@ client:
       # -- Image repository.
       repository: dragonflyoss/dfinit
       # -- Image tag.
-      tag: v1.0.0
+      tag: v1.0.1
       # -- Image digest.
       digest: ""
       # -- Image pull policy.
@@ -1316,7 +1316,7 @@ client:
       # -- rateLimit is the default rate limit of the download speed in GiB/Mib/Kib per second, default is 50GiB/s.
       rateLimit: 50GiB
       # --  pieceTimeout is the timeout for downloading a piece from source.
-      pieceTimeout: 120s
+      pieceTimeout: 40s
       # -- collected_piece_timeout is the timeout for collecting one piece from the parent in the stream.
       collectedPieceTimeout: 10s
       # -- concurrentPieceCount is the number of concurrent pieces to download.
@@ -1415,7 +1415,7 @@ client:
       # -- readBufferSize is the buffer size for reading piece from disk, default is 4MiB.
       readBufferSize: 4194304
       # -- writePieceTimeout is the timeout for writing a piece to storage(e.g., disk or cache).
-      writePieceTimeout: 90s
+      writePieceTimeout: 30s
     gc:
       # -- interval is the interval to do gc.
       interval: 900s


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the Dragonfly Helm chart to use newer versions of several images and components. The changes primarily involve bumping the image tags for `client`, `seed-client`, and `dfinit` from `v1.0.0` to `v1.0.1`, along with corresponding updates in the documentation and configuration files.

### Version updates:

* [`charts/dragonfly/Chart.yaml`](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L6-R6): Updated the chart version from `1.4.0` to `1.4.1` and bumped the `client` image version from `v1.0.0` to `v1.0.1` in the annotations section. [[1]](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L6-R6) [[2]](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L30-R30)

### Image tag updates:

* [`charts/dragonfly/Chart.yaml`](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L46-R49): Updated image tags for `client`, `seed-client`, and `dfinit` from `v1.0.0` to `v1.0.1` in the annotations section.
* [`charts/dragonfly/README.md`](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL181-R181): Updated documentation to reflect the new image tags for `client`, `seed-client`, and `dfinit`. [[1]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL181-R181) [[2]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL196-R196) [[3]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL482-R482)
* [`charts/dragonfly/values.yaml`](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL703-R703): Updated the `tag` field for `client`, `seed-client`, and `dfinit` images from `v1.0.0` to `v1.0.1`. [[1]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL703-R703) [[2]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL1128-R1128) [[3]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL1215-R1215)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
