### PR TITLE
chore: bump client to v1.0.12

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.4.5
+version: 1.4.6
 appVersion: 2.3.1-rc.4
 keywords:
   - dragonfly
@@ -27,8 +27,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Bump Dragonfly to v2.3.1-rc.4.
-    - Bump Client to v1.0.11.
+    - Bump Client to v1.0.12.
 
   artifacthub.io/links: |
     - name: Chart Source
@@ -43,11 +42,11 @@ annotations:
     - name: scheduler
       image: dragonflyoss/scheduler:v2.3.1-rc.4
     - name: client
-      image: dragonflyoss/client:v1.0.11
+      image: dragonflyoss/client:v1.0.12
     - name: seed-client
-      image: dragonflyoss/client:v1.0.11
+      image: dragonflyoss/client:v1.0.12
     - name: dfinit
-      image: dragonflyoss/dfinit:v1.0.11
+      image: dragonflyoss/dfinit:v1.0.12
 
 dependencies:
   - name: mysql

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -180,7 +180,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.dfinit.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | client.dfinit.image.registry | string | `"docker.io"` | Image registry. |
 | client.dfinit.image.repository | string | `"dragonflyoss/dfinit"` | Image repository. |
-| client.dfinit.image.tag | string | `"v1.0.11"` | Image tag. |
+| client.dfinit.image.tag | string | `"v1.0.12"` | Image tag. |
 | client.dfinit.restartContainerRuntime | bool | `true` | restartContainerRuntime indicates whether to restart container runtime when dfinit is enabled. it should be set to true when your first install dragonfly. If non-hot load configuration changes are made, the container runtime needs to be restarted. |
 | client.enable | bool | `true` | Enable client. |
 | client.extraVolumeMounts | list | `[{"mountPath":"/var/lib/dragonfly/","name":"storage"},{"mountPath":"/var/log/dragonfly/dfdaemon/","name":"logs"}]` | Extra volumeMounts for dfdaemon. |
@@ -195,7 +195,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | client.image.registry | string | `"docker.io"` | Image registry. |
 | client.image.repository | string | `"dragonflyoss/client"` | Image repository. |
-| client.image.tag | string | `"v1.0.11"` | Image tag. |
+| client.image.tag | string | `"v1.0.12"` | Image tag. |
 | client.initContainer.image.digest | string | `""` | Image digest. |
 | client.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | client.initContainer.image.registry | string | `"docker.io"` | Image registry. |
@@ -482,7 +482,7 @@ helm delete dragonfly --namespace dragonfly-system
 | seedClient.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | seedClient.image.registry | string | `"docker.io"` | Image registry. |
 | seedClient.image.repository | string | `"dragonflyoss/client"` | Image repository. |
-| seedClient.image.tag | string | `"v1.0.11"` | Image tag. |
+| seedClient.image.tag | string | `"v1.0.12"` | Image tag. |
 | seedClient.initContainer.image.digest | string | `""` | Image digest. |
 | seedClient.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | seedClient.initContainer.image.registry | string | `"docker.io"` | Image registry. |

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -702,7 +702,7 @@ seedClient:
     # -- Image repository.
     repository: dragonflyoss/client
     # -- Image tag.
-    tag: v1.0.11
+    tag: v1.0.12
     # -- Image digest.
     digest: ""
     # -- Image pull policy.
@@ -1129,7 +1129,7 @@ client:
     # -- Image repository.
     repository: dragonflyoss/client
     # -- Image tag.
-    tag: v1.0.11
+    tag: v1.0.12
     # -- Image digest.
     digest: ""
     # -- Image pull policy.
@@ -1216,7 +1216,7 @@ client:
       # -- Image repository.
       repository: dragonflyoss/dfinit
       # -- Image tag.
-      tag: v1.0.11
+      tag: v1.0.12
       # -- Image digest.
       digest: ""
       # -- Image pull policy.


### PR DESCRIPTION
This pull request updates the Dragonfly Helm chart to use the latest `v1.0.12` versions of the client and dfinit images, replacing the previous `v1.0.11` versions. It also updates related documentation and metadata to reflect these changes.

**Image version updates:**

* Updated the `client`, `seed-client`, and `dfinit` image tags from `v1.0.11` to `v1.0.12` in `charts/dragonfly/Chart.yaml` and `charts/dragonfly/values.yaml`. [[1]](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L46-R49) [[2]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL705-R705) [[3]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL1132-R1132) [[4]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL1219-R1219)
* Updated the documented default image tags for `client`, `seedClient`, and `dfinit` in `charts/dragonfly/README.md` to `v1.0.12`. [[1]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL183-R183) [[2]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL198-R198) [[3]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL485-R485)

**Metadata and documentation updates:**

* Updated the chart version to `1.4.6` in `charts/dragonfly/Chart.yaml`.
* Updated the `artifacthub.io/changes` annotation to reflect the new client version.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
