### PR TITLE
feat: bump client to v1.0.23 and bump dragonfly to v2.3.3-rc.0

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,8 +3,8 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.4.9
-appVersion: 2.3.2
+version: 1.4.10
+appVersion: 2.3.3-rc.0
 keywords:
   - dragonfly
   - d7y
@@ -27,8 +27,8 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Bump Client to v1.0.21.
-    - Bump Manager and Scheduler to v2.3.2.
+    - Bump Client to v1.0.23.
+    - Bump Manager and Scheduler to v2.3.3-rc.0.
 
   artifacthub.io/links: |
     - name: Chart Source
@@ -39,15 +39,15 @@ annotations:
       url: https://github.com/dragonflyoss/client
   artifacthub.io/images: |
     - name: manager
-     image: dragonflyoss/manager:v2.3.2
+     image: dragonflyoss/manager:v2.3.3-rc.0
     - name: scheduler
-      image: dragonflyoss/scheduler:v2.3.2
+      image: dragonflyoss/scheduler:v2.3.3-rc.0
     - name: client
-      image: dragonflyoss/client:v1.0.21
+      image: dragonflyoss/client:v1.0.23
     - name: seed-client
-      image: dragonflyoss/client:v1.0.21
+      image: dragonflyoss/client:v1.0.23
     - name: dfinit
-      image: dragonflyoss/dfinit:v1.0.21
+      image: dragonflyoss/dfinit:v1.0.23
 
 dependencies:
   - name: mysql

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -133,6 +133,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.config.download.collectedPieceTimeout | string | `"10s"` | collected_piece_timeout is the timeout for collecting one piece from the parent in the stream. |
 | client.config.download.concurrentPieceCount | int | `8` | concurrentPieceCount is the number of concurrent pieces to download. |
 | client.config.download.pieceTimeout | string | `"40s"` | pieceTimeout is the timeout for downloading a piece from source. |
+| client.config.download.protocol | string | `"tcp"` | Protocol that peers use to download piece (e.g., "tcp", "quic"). When dfdaemon acts as a parent, it announces this protocol so downstream peers fetch pieces using it. |
 | client.config.download.rateLimit | string | `"50GiB"` | rateLimit is the default rate limit of the download speed in GiB/Mib/Kib per second, default is 50GiB/s. |
 | client.config.download.server.requestRateLimit | int | `4000` | request_rate_limit is the rate limit of the download request in the download grpc server, default is 4000 req/s. |
 | client.config.download.server.socketPath | string | `"/var/run/dragonfly/dfdaemon.sock"` | socketPath is the unix socket path for dfdaemon GRPC service. |
@@ -163,6 +164,8 @@ helm delete dragonfly --namespace dragonfly-system
 | client.config.storage.dir | string | `"/var/lib/dragonfly/"` | dir is the directory to store task's metadata and content. |
 | client.config.storage.keep | bool | `true` | keep indicates whether keep the task's metadata and content when the dfdaemon restarts. |
 | client.config.storage.readBufferSize | int | `4194304` | readBufferSize is the buffer size for reading piece from disk, default is 4MiB. |
+| client.config.storage.server.quicPort | int | `4006` | port is the port to the quic server. |
+| client.config.storage.server.tcpPort | int | `4005` | port is the port to the tcp server. |
 | client.config.storage.writeBufferSize | int | `4194304` | writeBufferSize is the buffer size for writing piece to disk, default is 4MiB. |
 | client.config.storage.writePieceTimeout | string | `"30s"` | writePieceTimeout is the timeout for writing a piece to storage(e.g., disk or cache). |
 | client.config.tracing.protocol | string | `""` | Protocol specifies the communication protocol for the tracing server. Supported values: "http", "https", "grpc" (default: None). This determines how tracing logs are transmitted to the server. |
@@ -180,7 +183,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.dfinit.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | client.dfinit.image.registry | string | `"docker.io"` | Image registry. |
 | client.dfinit.image.repository | string | `"dragonflyoss/dfinit"` | Image repository. |
-| client.dfinit.image.tag | string | `"v1.0.21"` | Image tag. |
+| client.dfinit.image.tag | string | `"v1.0.23"` | Image tag. |
 | client.dfinit.restartContainerRuntime | bool | `true` | restartContainerRuntime indicates whether to restart container runtime when dfinit is enabled. it should be set to true when your first install dragonfly. If non-hot load configuration changes are made, the container runtime needs to be restarted. |
 | client.enable | bool | `true` | Enable client. |
 | client.extraVolumeMounts | list | `[{"mountPath":"/var/lib/dragonfly/","name":"storage"},{"mountPath":"/var/log/dragonfly/dfdaemon/","name":"logs"}]` | Extra volumeMounts for dfdaemon. |
@@ -195,7 +198,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | client.image.registry | string | `"docker.io"` | Image registry. |
 | client.image.repository | string | `"dragonflyoss/client"` | Image repository. |
-| client.image.tag | string | `"v1.0.21"` | Image tag. |
+| client.image.tag | string | `"v1.0.23"` | Image tag. |
 | client.initContainer.image.digest | string | `""` | Image digest. |
 | client.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | client.initContainer.image.registry | string | `"docker.io"` | Image registry. |
@@ -293,7 +296,7 @@ helm delete dragonfly --namespace dragonfly-system
 | manager.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | manager.image.registry | string | `"docker.io"` | Image registry. |
 | manager.image.repository | string | `"dragonflyoss/manager"` | Image repository. |
-| manager.image.tag | string | `"v2.3.2"` | Image tag. |
+| manager.image.tag | string | `"v2.3.3-rc.0"` | Image tag. |
 | manager.ingress.annotations | object | `{}` | Ingress annotations. |
 | manager.ingress.className | string | `""` | Ingress class name. Requirement: kubernetes >=1.18. |
 | manager.ingress.enable | bool | `false` | Enable ingress. |
@@ -396,7 +399,7 @@ helm delete dragonfly --namespace dragonfly-system
 | scheduler.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | scheduler.image.registry | string | `"docker.io"` | Image registry. |
 | scheduler.image.repository | string | `"dragonflyoss/scheduler"` | Image repository. |
-| scheduler.image.tag | string | `"v2.3.2"` | Image tag. |
+| scheduler.image.tag | string | `"v2.3.3-rc.0"` | Image tag. |
 | scheduler.initContainer.image.digest | string | `""` | Image digest. |
 | scheduler.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | scheduler.initContainer.image.registry | string | `"docker.io"` | Image registry. |
@@ -436,6 +439,7 @@ helm delete dragonfly --namespace dragonfly-system
 | seedClient.config.download.collectedPieceTimeout | string | `"10s"` | collected_piece_timeout is the timeout for collecting one piece from the parent in the stream. |
 | seedClient.config.download.concurrentPieceCount | int | `16` | concurrentPieceCount is the number of concurrent pieces to download. |
 | seedClient.config.download.pieceTimeout | string | `"40s"` | pieceTimeout is the timeout for downloading a piece from source. |
+| seedClient.config.download.protocol | string | `"tcp"` | Protocol that peers use to download piece (e.g., "tcp", "quic"). When dfdaemon acts as a parent, it announces this protocol so downstream peers fetch pieces using it. |
 | seedClient.config.download.rateLimit | string | `"50GiB"` | rateLimit is the default rate limit of the download speed in GiB/Mib/Kib per second, default is 50GiB/s. |
 | seedClient.config.download.server.requestRateLimit | int | `4000` | request_rate_limit is the rate limit of the download request in the download grpc server, default is 4000 req/s. |
 | seedClient.config.download.server.socketPath | string | `"/var/run/dragonfly/dfdaemon.sock"` | socketPath is the unix socket path for dfdaemon GRPC service. |
@@ -467,6 +471,8 @@ helm delete dragonfly --namespace dragonfly-system
 | seedClient.config.storage.dir | string | `"/var/lib/dragonfly/"` | dir is the directory to store task's metadata and content. |
 | seedClient.config.storage.keep | bool | `true` | keep indicates whether keep the task's metadata and content when the dfdaemon restarts. |
 | seedClient.config.storage.readBufferSize | int | `4194304` | readBufferSize is the buffer size for reading piece from disk, default is 4MiB. |
+| seedClient.config.storage.server.quicPort | int | `4006` | port is the port to the quic server. |
+| seedClient.config.storage.server.tcpPort | int | `4005` | port is the port to the tcp server. |
 | seedClient.config.storage.writeBufferSize | int | `4194304` | writeBufferSize is the buffer size for writing piece to disk, default is 4MiB. |
 | seedClient.config.storage.writePieceTimeout | string | `"30s"` | writePieceTimeout is the timeout for writing a piece to storage(e.g., disk or cache). |
 | seedClient.config.tracing.protocol | string | `""` | Protocol specifies the communication protocol for the tracing server. Supported values: "http", "https", "grpc" (default: None). This determines how tracing logs are transmitted to the server. |
@@ -484,7 +490,7 @@ helm delete dragonfly --namespace dragonfly-system
 | seedClient.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | seedClient.image.registry | string | `"docker.io"` | Image registry. |
 | seedClient.image.repository | string | `"dragonflyoss/client"` | Image repository. |
-| seedClient.image.tag | string | `"v1.0.21"` | Image tag. |
+| seedClient.image.tag | string | `"v1.0.23"` | Image tag. |
 | seedClient.initContainer.image.digest | string | `""` | Image digest. |
 | seedClient.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | seedClient.initContainer.image.registry | string | `"docker.io"` | Image registry. |

--- a/charts/dragonfly/templates/client/client-daemonset.yaml
+++ b/charts/dragonfly/templates/client/client-daemonset.yaml
@@ -163,6 +163,10 @@ spec:
           protocol: TCP
         - containerPort: {{ .Values.client.config.stats.server.port }}
           protocol: TCP
+        - containerPort: {{ .Values.client.config.storage.server.tcpPort }}
+          protocol: TCP
+        - containerPort: {{ .Values.client.config.storage.server.quicPort }}
+          protocol: TCP
         readinessProbe:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=unix://{{ .Values.client.config.download.server.socketPath }}"]

--- a/charts/dragonfly/templates/seed-client/seed-client-statefulset.yaml
+++ b/charts/dragonfly/templates/seed-client/seed-client-statefulset.yaml
@@ -106,6 +106,10 @@ spec:
           protocol: TCP
         - containerPort: {{ .Values.seedClient.config.stats.server.port }}
           protocol: TCP
+        - containerPort: {{ .Values.seedClient.config.storage.server.tcpPort }}
+          protocol: TCP
+        - containerPort: {{ .Values.seedClient.config.storage.server.quicPort }}
+          protocol: TCP
         readinessProbe:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=unix://{{ .Values.seedClient.config.download.server.socketPath }}"]

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -39,7 +39,7 @@ manager:
     # -- Image repository.
     repository: dragonflyoss/manager
     # -- Image tag.
-    tag: v2.3.2
+    tag: v2.3.3-rc.0
     # -- Image digest.
     digest: ""
     # -- Image pull policy.
@@ -322,7 +322,7 @@ scheduler:
     # -- Image repository.
     repository: dragonflyoss/scheduler
     # -- Image tag.
-    tag: v2.3.2
+    tag: v2.3.3-rc.0
     # -- Image digest.
     digest: ""
     # -- Image pull policy.
@@ -702,7 +702,7 @@ seedClient:
     # -- Image repository.
     repository: dragonflyoss/client
     # -- Image tag.
-    tag: v1.0.21
+    tag: v1.0.23
     # -- Image digest.
     digest: ""
     # -- Image pull policy.
@@ -825,6 +825,10 @@ seedClient:
         socketPath: /var/run/dragonfly/dfdaemon.sock
         # -- request_rate_limit is the rate limit of the download request in the download grpc server, default is 4000 req/s.
         requestRateLimit: 4000
+      # -- Protocol that peers use to download piece (e.g., "tcp", "quic").
+      # When dfdaemon acts as a parent, it announces this protocol so downstream
+      # peers fetch pieces using it.
+      protocol: tcp
       # -- rateLimit is the default rate limit of the download speed in GiB/Mib/Kib per second, default is 50GiB/s.
       rateLimit: 50GiB
       # --  pieceTimeout is the timeout for downloading a piece from source.
@@ -919,6 +923,13 @@ seedClient:
       # -- refreshInterval is the interval to refresh dynamic configuration from manager.
       refreshInterval: 1m
     storage:
+      server:
+        # -- port is the port to the tcp server.
+        tcpPort: 4005
+        # -- port is the port to the quic server.
+        quicPort: 4006
+      # # ip is the listen ip of the storage server.
+      # ip: ""
       # -- dir is the directory to store task's metadata and content.
       dir: /var/lib/dragonfly/
       # -- keep indicates whether keep the task's metadata and content when the dfdaemon restarts.
@@ -1129,7 +1140,7 @@ client:
     # -- Image repository.
     repository: dragonflyoss/client
     # -- Image tag.
-    tag: v1.0.21
+    tag: v1.0.23
     # -- Image digest.
     digest: ""
     # -- Image pull policy.
@@ -1216,7 +1227,7 @@ client:
       # -- Image repository.
       repository: dragonflyoss/dfinit
       # -- Image tag.
-      tag: v1.0.21
+      tag: v1.0.23
       # -- Image digest.
       digest: ""
       # -- Image pull policy.
@@ -1317,6 +1328,10 @@ client:
       # -- cacheDir is the directory to store cache files.
       cacheDir: /var/cache/dragonfly/dfdaemon/
     download:
+      # -- Protocol that peers use to download piece (e.g., "tcp", "quic").
+      # When dfdaemon acts as a parent, it announces this protocol so downstream
+      # peers fetch pieces using it.
+      protocol: tcp
       server:
         # -- socketPath is the unix socket path for dfdaemon GRPC service.
         socketPath: /var/run/dragonfly/dfdaemon.sock
@@ -1415,6 +1430,13 @@ client:
       # -- refreshInterval is the interval to refresh dynamic configuration from manager.
       refreshInterval: 5m
     storage:
+      server:
+        # -- port is the port to the tcp server.
+        tcpPort: 4005
+        # -- port is the port to the quic server.
+        quicPort: 4006
+      # # ip is the listen ip of the storage server.
+      # ip: ""
       # -- dir is the directory to store task's metadata and content.
       dir: /var/lib/dragonfly/
       # -- keep indicates whether keep the task's metadata and content when the dfdaemon restarts.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the Dragonfly Helm chart to support new features and versions, primarily introducing configurable download protocols (TCP/QUIC), adding explicit storage server ports, and bumping component images to the latest release candidates. These changes improve flexibility for peer communication and prepare the chart for the upcoming Dragonfly 2.3.3 release.

**Version and Image Updates:**

- Upgrades the chart version to `1.4.10` and the app version to `2.3.3-rc.0`, and updates all relevant component images (`manager`, `scheduler`, `client`, `seed-client`, `dfinit`) to their latest versions. [[1]](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L6-R7) [[2]](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L30-R31) [[3]](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L42-R50) [[4]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL183-R186) [[5]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL198-R201) [[6]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL296-R299) [[7]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL399-R402) [[8]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL487-R493) [[9]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL42-R42) [[10]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL325-R325) [[11]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL705-R705) [[12]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL1132-R1143) [[13]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL1219-R1230)

**Configurable Download Protocols:**

- Adds a `protocol` field to both `client` and `seedClient` download configuration, allowing users to specify the protocol used for piece downloads (e.g., "tcp", "quic"). This is reflected in both the `values.yaml` and documentation. [[1]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bR1331-R1334) [[2]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bR828-R831) [[3]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR167-R168) [[4]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR442)

**Storage Server Port Configuration:**

- Introduces explicit configuration for `tcpPort` and `quicPort` under the storage server settings for both `client` and `seedClient`, with corresponding documentation and default values. [[1]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bR1433-R1439) [[2]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bR926-R932) [[3]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR167-R168) [[4]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR474-R475)

**Template and Manifest Updates:**

- Updates the `client-daemonset.yaml` and `seed-client-statefulset.yaml` templates to expose the new TCP and QUIC ports as container ports, ensuring they are available for peer communication. [[1]](diffhunk://#diff-8cf66934693161309da9877cfb771789762f3385911bfbef625d3990182de2f9R166-R169) [[2]](diffhunk://#diff-6d654bfeacaa663ab0bcb823c3429c8dae1c469d46a9c8d6032ab065b471a1a9R109-R112)

**Documentation Improvements:**

- Updates the `README.md` to document new configuration options for download protocol and storage server ports, and to reflect the new image tags and versions. [[1]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR167-R168) [[2]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL183-R186) [[3]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL198-R201) [[4]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL296-R299) [[5]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL399-R402) [[6]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR442) [[7]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR474-R475) [[8]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL487-R493)

These changes collectively enhance Dragonfly's flexibility and readiness for the next release.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
