### PR TITLE
docs: Update description for download.protocol

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.4.11
+version: 1.4.12
 appVersion: 2.3.3-rc.1
 keywords:
   - dragonfly
@@ -27,8 +27,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Bump Client to v1.0.26.
-    - Bump Manager and Scheduler to v2.3.3-rc.1.
+    - Update description for download.protocol.
 
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -133,7 +133,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.config.download.collectedPieceTimeout | string | `"10s"` | collected_piece_timeout is the timeout for collecting one piece from the parent in the stream. |
 | client.config.download.concurrentPieceCount | int | `8` | concurrentPieceCount is the number of concurrent pieces to download. |
 | client.config.download.pieceTimeout | string | `"40s"` | pieceTimeout is the timeout for downloading a piece from source. |
-| client.config.download.protocol | string | `"tcp"` | Protocol that peers use to download piece (e.g., "tcp", "quic"). When dfdaemon acts as a parent, it announces this protocol so downstream peers fetch pieces using it. |
+| client.config.download.protocol | string | `"tcp"` | protocol that peers use to download piece, supported values: "tcp", "quic". When dfdaemon acts as a parent, it announces this protocol so downstream peers fetch pieces using it. QUIC: Recommended for high-bandwidth, long-RTT, or lossy networks. TCP: Recommended for high-bandwidth, low-RTT, or local-area network (LAN) environments. |
 | client.config.download.rateLimit | string | `"50GiB"` | rateLimit is the default rate limit of the download speed in GiB/Mib/Kib per second, default is 50GiB/s. |
 | client.config.download.server.requestRateLimit | int | `4000` | request_rate_limit is the rate limit of the download request in the download grpc server, default is 4000 req/s. |
 | client.config.download.server.socketPath | string | `"/var/run/dragonfly/dfdaemon.sock"` | socketPath is the unix socket path for dfdaemon GRPC service. |
@@ -439,7 +439,7 @@ helm delete dragonfly --namespace dragonfly-system
 | seedClient.config.download.collectedPieceTimeout | string | `"10s"` | collected_piece_timeout is the timeout for collecting one piece from the parent in the stream. |
 | seedClient.config.download.concurrentPieceCount | int | `16` | concurrentPieceCount is the number of concurrent pieces to download. |
 | seedClient.config.download.pieceTimeout | string | `"40s"` | pieceTimeout is the timeout for downloading a piece from source. |
-| seedClient.config.download.protocol | string | `"tcp"` | Protocol that peers use to download piece (e.g., "tcp", "quic"). When dfdaemon acts as a parent, it announces this protocol so downstream peers fetch pieces using it. |
+| seedClient.config.download.protocol | string | `"tcp"` | protocol that peers use to download piece, supported values: "tcp", "quic". When dfdaemon acts as a parent, it announces this protocol so downstream peers fetch pieces using it. QUIC: Recommended for high-bandwidth, long-RTT, or lossy networks. TCP: Recommended for high-bandwidth, low-RTT, or local-area network (LAN) environments. |
 | seedClient.config.download.rateLimit | string | `"50GiB"` | rateLimit is the default rate limit of the download speed in GiB/Mib/Kib per second, default is 50GiB/s. |
 | seedClient.config.download.server.requestRateLimit | int | `4000` | request_rate_limit is the rate limit of the download request in the download grpc server, default is 4000 req/s. |
 | seedClient.config.download.server.socketPath | string | `"/var/run/dragonfly/dfdaemon.sock"` | socketPath is the unix socket path for dfdaemon GRPC service. |

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -825,9 +825,11 @@ seedClient:
         socketPath: /var/run/dragonfly/dfdaemon.sock
         # -- request_rate_limit is the rate limit of the download request in the download grpc server, default is 4000 req/s.
         requestRateLimit: 4000
-      # -- Protocol that peers use to download piece (e.g., "tcp", "quic").
+      # -- protocol that peers use to download piece, supported values: "tcp", "quic".
       # When dfdaemon acts as a parent, it announces this protocol so downstream
       # peers fetch pieces using it.
+      # QUIC: Recommended for high-bandwidth, long-RTT, or lossy networks.
+      # TCP: Recommended for high-bandwidth, low-RTT, or local-area network (LAN) environments.
       protocol: tcp
       # -- rateLimit is the default rate limit of the download speed in GiB/Mib/Kib per second, default is 50GiB/s.
       rateLimit: 50GiB
@@ -1328,9 +1330,11 @@ client:
       # -- cacheDir is the directory to store cache files.
       cacheDir: /var/cache/dragonfly/dfdaemon/
     download:
-      # -- Protocol that peers use to download piece (e.g., "tcp", "quic").
+      # -- protocol that peers use to download piece, supported values: "tcp", "quic".
       # When dfdaemon acts as a parent, it announces this protocol so downstream
       # peers fetch pieces using it.
+      # QUIC: Recommended for high-bandwidth, long-RTT, or lossy networks.
+      # TCP: Recommended for high-bandwidth, low-RTT, or local-area network (LAN) environments.
       protocol: tcp
       server:
         # -- socketPath is the unix socket path for dfdaemon GRPC service.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates documentation and configuration comments for the `download.protocol` option in the Dragonfly Helm chart. The changes clarify the recommended use cases for the supported protocols ("tcp" and "quic") and improve the descriptions for users. Additionally, the chart version is bumped to reflect these documentation updates.

**Documentation and description improvements:**

* Updated the `download.protocol` descriptions in both `client` and `seedClient` sections of `values.yaml` to specify supported values and provide recommendations for when to use "quic" vs "tcp". [[1]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL828-R832) [[2]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL1331-R1337)
* Enhanced the protocol descriptions in the `README.md` for both `client.config.download.protocol` and `seedClient.config.download.protocol`, including guidance on protocol selection based on network conditions. [[1]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL136-R136) [[2]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL442-R442)
* Updated the chart change log in `Chart.yaml` to mention the improved description for `download.protocol`.

**Version update:**

* Bumped the Helm chart version from `1.4.11` to `1.4.12` in `Chart.yaml` to reflect these documentation improvements.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
