### PR TITLE
chore: bump dragonfly to v2.3.3

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,8 +3,8 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.4.12
-appVersion: 2.3.3-rc.1
+version: 1.4.13
+appVersion: 2.3.3
 keywords:
   - dragonfly
   - d7y
@@ -27,7 +27,8 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Update description for download.protocol.
+    - Bump dragonfly to v2.3.3.
+    - Bump client to v1.0.27.
 
   artifacthub.io/links: |
     - name: Chart Source
@@ -38,15 +39,15 @@ annotations:
       url: https://github.com/dragonflyoss/client
   artifacthub.io/images: |
     - name: manager
-     image: dragonflyoss/manager:v2.3.3-rc.1
+     image: dragonflyoss/manager:v2.3.3
     - name: scheduler
-      image: dragonflyoss/scheduler:v2.3.3-rc.1
+      image: dragonflyoss/scheduler:v2.3.3
     - name: client
-      image: dragonflyoss/client:v1.0.26
+      image: dragonflyoss/client:v1.0.27
     - name: seed-client
-      image: dragonflyoss/client:v1.0.26
+      image: dragonflyoss/client:v1.0.27
     - name: dfinit
-      image: dragonflyoss/dfinit:v1.0.26
+      image: dragonflyoss/dfinit:v1.0.27
 
 dependencies:
   - name: mysql

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -131,7 +131,7 @@ helm delete dragonfly --namespace dragonfly-system
 |-----|------|---------|-------------|
 | client.config.console | bool | `true` | console prints log. |
 | client.config.download.collectedPieceTimeout | string | `"10s"` | collected_piece_timeout is the timeout for collecting one piece from the parent in the stream. |
-| client.config.download.concurrentPieceCount | int | `8` | concurrentPieceCount is the number of concurrent pieces to download. |
+| client.config.download.concurrentPieceCount | int | `16` | concurrentPieceCount is the number of concurrent pieces to download. |
 | client.config.download.pieceTimeout | string | `"40s"` | pieceTimeout is the timeout for downloading a piece from source. |
 | client.config.download.protocol | string | `"tcp"` | protocol that peers use to download piece, supported values: "tcp", "quic". When dfdaemon acts as a parent, it announces this protocol so downstream peers fetch pieces using it. QUIC: Recommended for high-bandwidth, long-RTT, or lossy networks. TCP: Recommended for high-bandwidth, low-RTT, or local-area network (LAN) environments. |
 | client.config.download.rateLimit | string | `"50GiB"` | rateLimit is the default rate limit of the download speed in GiB/Mib/Kib per second, default is 50GiB/s. |
@@ -183,7 +183,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.dfinit.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | client.dfinit.image.registry | string | `"docker.io"` | Image registry. |
 | client.dfinit.image.repository | string | `"dragonflyoss/dfinit"` | Image repository. |
-| client.dfinit.image.tag | string | `"v1.0.26"` | Image tag. |
+| client.dfinit.image.tag | string | `"v1.0.27"` | Image tag. |
 | client.dfinit.restartContainerRuntime | bool | `true` | restartContainerRuntime indicates whether to restart container runtime when dfinit is enabled. it should be set to true when your first install dragonfly. If non-hot load configuration changes are made, the container runtime needs to be restarted. |
 | client.enable | bool | `true` | Enable client. |
 | client.extraVolumeMounts | list | `[{"mountPath":"/var/lib/dragonfly/","name":"storage"},{"mountPath":"/var/log/dragonfly/dfdaemon/","name":"logs"}]` | Extra volumeMounts for dfdaemon. |
@@ -198,7 +198,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | client.image.registry | string | `"docker.io"` | Image registry. |
 | client.image.repository | string | `"dragonflyoss/client"` | Image repository. |
-| client.image.tag | string | `"v1.0.26"` | Image tag. |
+| client.image.tag | string | `"v1.0.27"` | Image tag. |
 | client.initContainer.image.digest | string | `""` | Image digest. |
 | client.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | client.initContainer.image.registry | string | `"docker.io"` | Image registry. |
@@ -296,7 +296,7 @@ helm delete dragonfly --namespace dragonfly-system
 | manager.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | manager.image.registry | string | `"docker.io"` | Image registry. |
 | manager.image.repository | string | `"dragonflyoss/manager"` | Image repository. |
-| manager.image.tag | string | `"v2.3.3-rc.1"` | Image tag. |
+| manager.image.tag | string | `"v2.3.3"` | Image tag. |
 | manager.ingress.annotations | object | `{}` | Ingress annotations. |
 | manager.ingress.className | string | `""` | Ingress class name. Requirement: kubernetes >=1.18. |
 | manager.ingress.enable | bool | `false` | Enable ingress. |
@@ -399,7 +399,7 @@ helm delete dragonfly --namespace dragonfly-system
 | scheduler.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | scheduler.image.registry | string | `"docker.io"` | Image registry. |
 | scheduler.image.repository | string | `"dragonflyoss/scheduler"` | Image repository. |
-| scheduler.image.tag | string | `"v2.3.3-rc.1"` | Image tag. |
+| scheduler.image.tag | string | `"v2.3.3"` | Image tag. |
 | scheduler.initContainer.image.digest | string | `""` | Image digest. |
 | scheduler.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | scheduler.initContainer.image.registry | string | `"docker.io"` | Image registry. |
@@ -437,7 +437,7 @@ helm delete dragonfly --namespace dragonfly-system
 | scheduler.updateStrategy | object | `{}` | Update strategy for replicas. |
 | seedClient.config.console | bool | `true` | console prints log. |
 | seedClient.config.download.collectedPieceTimeout | string | `"10s"` | collected_piece_timeout is the timeout for collecting one piece from the parent in the stream. |
-| seedClient.config.download.concurrentPieceCount | int | `16` | concurrentPieceCount is the number of concurrent pieces to download. |
+| seedClient.config.download.concurrentPieceCount | int | `32` | concurrentPieceCount is the number of concurrent pieces to download. |
 | seedClient.config.download.pieceTimeout | string | `"40s"` | pieceTimeout is the timeout for downloading a piece from source. |
 | seedClient.config.download.protocol | string | `"tcp"` | protocol that peers use to download piece, supported values: "tcp", "quic". When dfdaemon acts as a parent, it announces this protocol so downstream peers fetch pieces using it. QUIC: Recommended for high-bandwidth, long-RTT, or lossy networks. TCP: Recommended for high-bandwidth, low-RTT, or local-area network (LAN) environments. |
 | seedClient.config.download.rateLimit | string | `"50GiB"` | rateLimit is the default rate limit of the download speed in GiB/Mib/Kib per second, default is 50GiB/s. |
@@ -490,7 +490,7 @@ helm delete dragonfly --namespace dragonfly-system
 | seedClient.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | seedClient.image.registry | string | `"docker.io"` | Image registry. |
 | seedClient.image.repository | string | `"dragonflyoss/client"` | Image repository. |
-| seedClient.image.tag | string | `"v1.0.26"` | Image tag. |
+| seedClient.image.tag | string | `"v1.0.27"` | Image tag. |
 | seedClient.initContainer.image.digest | string | `""` | Image digest. |
 | seedClient.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | seedClient.initContainer.image.registry | string | `"docker.io"` | Image registry. |

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -39,7 +39,7 @@ manager:
     # -- Image repository.
     repository: dragonflyoss/manager
     # -- Image tag.
-    tag: v2.3.3-rc.1
+    tag: v2.3.3
     # -- Image digest.
     digest: ""
     # -- Image pull policy.
@@ -322,7 +322,7 @@ scheduler:
     # -- Image repository.
     repository: dragonflyoss/scheduler
     # -- Image tag.
-    tag: v2.3.3-rc.1
+    tag: v2.3.3
     # -- Image digest.
     digest: ""
     # -- Image pull policy.
@@ -702,7 +702,7 @@ seedClient:
     # -- Image repository.
     repository: dragonflyoss/client
     # -- Image tag.
-    tag: v1.0.26
+    tag: v1.0.27
     # -- Image digest.
     digest: ""
     # -- Image pull policy.
@@ -838,7 +838,7 @@ seedClient:
       # -- collected_piece_timeout is the timeout for collecting one piece from the parent in the stream.
       collectedPieceTimeout: 10s
       # -- concurrentPieceCount is the number of concurrent pieces to download.
-      concurrentPieceCount: 16
+      concurrentPieceCount: 32
     upload:
       server:
         # -- port is the port to the grpc server.
@@ -1142,7 +1142,7 @@ client:
     # -- Image repository.
     repository: dragonflyoss/client
     # -- Image tag.
-    tag: v1.0.26
+    tag: v1.0.27
     # -- Image digest.
     digest: ""
     # -- Image pull policy.
@@ -1229,7 +1229,7 @@ client:
       # -- Image repository.
       repository: dragonflyoss/dfinit
       # -- Image tag.
-      tag: v1.0.26
+      tag: v1.0.27
       # -- Image digest.
       digest: ""
       # -- Image pull policy.
@@ -1348,7 +1348,7 @@ client:
       # -- collected_piece_timeout is the timeout for collecting one piece from the parent in the stream.
       collectedPieceTimeout: 10s
       # -- concurrentPieceCount is the number of concurrent pieces to download.
-      concurrentPieceCount: 8
+      concurrentPieceCount: 16
     upload:
       server:
         # -- port is the port to the grpc server.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the Dragonfly Helm chart and its documentation to use the latest stable component versions and improves default download concurrency settings for better performance. The most important changes are grouped below:

**Version and Image Updates:**

* Updated the chart version to `1.4.13` and the app version to `2.3.3` in `Chart.yaml`, reflecting the latest stable release.
* Updated all component images (`manager`, `scheduler`, `client`, `seed-client`, `dfinit`) from release candidate or previous versions to their latest stable tags in `Chart.yaml`, `values.yaml`, and `README.md`. [[1]](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L41-R50) [[2]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL42-R42) [[3]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL325-R325) [[4]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL705-R705) [[5]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL1145-R1145) [[6]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL1232-R1232) [[7]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL186-R186) [[8]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL201-R201) [[9]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL299-R299) [[10]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL402-R402) [[11]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL493-R493)
* Updated the release notes and change annotations to reflect the new versions and client bump.

**Configuration Improvements:**

* Increased the default `concurrentPieceCount` for the client from 8 to 16 and for the seed client from 16 to 32 in both `values.yaml` and `README.md`, allowing more concurrent downloads by default for improved throughput. [[1]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL841-R841) [[2]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL1351-R1351) [[3]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL134-R134) [[4]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL440-R440)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
