### PR TITLE
fix: manager addr config for dfdaemon

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.4.14
+version: 1.4.15
 appVersion: 2.3.3
 keywords:
   - dragonfly
@@ -27,8 +27,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Bump dragonfly to v2.3.3.
-    - Bump client to v1.0.27.
+    - Fix manager addr config for client.
 
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/dragonfly/templates/client/client-configmap.yaml
+++ b/charts/dragonfly/templates/client/client-configmap.yaml
@@ -20,7 +20,7 @@ data:
     upload:
 {{ toYaml .Values.client.config.upload | indent 6 }}
     manager:
-      {{- if .Values.client.config.manager.addrs }}
+      {{- if .Values.client.config.manager.addr }}
       addr: {{ .Values.client.config.manager.addr }}
       {{- else if .Values.manager.enable }}
       addr: http://{{ template "dragonfly.manager.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.manager.grpcPort }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request addresses a configuration issue for the Dragonfly client in the Helm chart, ensuring the manager address is set correctly. The chart version is also bumped to reflect this fix.

Helm chart improvements:

* Fixed the client configuration logic in `client-configmap.yaml` to use the correct `manager.addr` value instead of `manager.addrs`, ensuring that the manager address is properly set for the client.
* Updated the change log annotation in `Chart.yaml` to note the fix for the manager address configuration.

Version update:

* Bumped the Helm chart version from `1.4.14` to `1.4.15` in `Chart.yaml` to reflect the configuration fix.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
