### PR TITLE
feat: add PostgreSQL support for manager database

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.6.23
+version: 1.6.24
 appVersion: 2.4.4-rc.1
 keywords:
   - dragonfly
@@ -27,9 +27,8 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Bump dragonfly version to v2.4.4-rc.1.
-    - Bump client version to v1.3.6.
-    - Add proxyAllRegistries configuration to support containerd to pull images.
+    - Add PostgreSQL support for manager database.
+    - Add extra init containers support for manager.
 
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.7.8
+version: 1.7.9
 appVersion: 2.5.1
 keywords:
   - dragonfly

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -250,6 +250,15 @@ helm delete dragonfly --namespace dragonfly-system
 | externalMysql.password | string | `"dragonfly"` | External mysql password. |
 | externalMysql.port | int | `3306` | External mysql port. |
 | externalMysql.username | string | `"dragonfly"` | External mysql username. |
+| externalPostgres.database | string | `"manager"` | External postgres database name. |
+| externalPostgres.enable | bool | `false` | Enable external PostgreSQL instead of MySQL. When enabled, the manager mounts a config-rendered emptyDir instead of the ConfigMap directly. Use manager.extraInitContainers to copy and patch the config (e.g. inject credentials from a Kubernetes Secret):  manager:   extraInitContainers:     - name: inject-pg-credentials       image: busybox:latest       command:         - sh         - -c         - |           sed "s/__PG_USER__/$PG_USER/g; s/__PG_PASSWORD__/$PG_PASSWORD/g" \             /etc/dragonfly-template/manager.yaml > /etc/dragonfly/manager.yaml       env:         - name: PG_USER           valueFrom:             secretKeyRef:               name: my-postgres-secret               key: username         - name: PG_PASSWORD           valueFrom:             secretKeyRef:               name: my-postgres-secret               key: password       volumeMounts:         - name: config           mountPath: /etc/dragonfly-template         - name: config-rendered           mountPath: /etc/dragonfly |
+| externalPostgres.host | string | `nil` | External postgres hostname. |
+| externalPostgres.migrate | bool | `true` | Running GORM migration. |
+| externalPostgres.password | string | `"dragonfly"` | External postgres password. Set to a placeholder (e.g. __PG_PASSWORD__) when using an extraInitContainers to inject credentials from a Secret. |
+| externalPostgres.port | int | `5432` | External postgres port. |
+| externalPostgres.sslMode | string | `"disable"` | External postgres SSL mode. |
+| externalPostgres.timezone | string | `"UTC"` | External postgres timezone. |
+| externalPostgres.username | string | `"dragonfly"` | External postgres username. Set to a placeholder (e.g. __PG_USER__) when using an extraInitContainers to inject credentials from a Secret. |
 | externalRedis.addrs | list | `["redis.example.com:6379"]` | External redis server addresses. |
 | externalRedis.backendDB | int | `2` | External redis backend db. |
 | externalRedis.brokerDB | int | `1` | External redis broker db. |
@@ -337,6 +346,7 @@ helm delete dragonfly --namespace dragonfly-system
 | manager.deploymentAnnotations | object | `{}` | Deployment annotations. |
 | manager.enable | bool | `true` | Enable manager. |
 | manager.extraEnvVars | list | `[]` | Extra environment variables for pod. |
+| manager.extraInitContainers | list | `[]` | Extra init containers for manager. |
 | manager.extraVolumeMounts | list | `[{"mountPath":"/var/log/dragonfly/manager","name":"logs"}]` | Extra volumeMounts for manager. |
 | manager.extraVolumes | list | `[{"emptyDir":{},"name":"logs"}]` | Extra volumes for manager. |
 | manager.fullnameOverride | string | `""` | Override manager fullname. |

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -251,14 +251,14 @@ helm delete dragonfly --namespace dragonfly-system
 | externalMysql.port | int | `3306` | External mysql port. |
 | externalMysql.username | string | `"dragonfly"` | External mysql username. |
 | externalPostgres.database | string | `"manager"` | External postgres database name. |
-| externalPostgres.enable | bool | `false` | Enable external PostgreSQL instead of MySQL. When enabled, the manager mounts a config-rendered emptyDir instead of the ConfigMap directly. Use manager.extraInitContainers to copy and patch the config (e.g. inject credentials from a Kubernetes Secret):  manager:   extraInitContainers:     - name: inject-pg-credentials       image: busybox:latest       command:         - sh         - -c         - |           sed "s/__PG_USER__/$PG_USER/g; s/__PG_PASSWORD__/$PG_PASSWORD/g" \             /etc/dragonfly-template/manager.yaml > /etc/dragonfly/manager.yaml       env:         - name: PG_USER           valueFrom:             secretKeyRef:               name: my-postgres-secret               key: username         - name: PG_PASSWORD           valueFrom:             secretKeyRef:               name: my-postgres-secret               key: password       volumeMounts:         - name: config           mountPath: /etc/dragonfly-template         - name: config-rendered           mountPath: /etc/dragonfly |
+| externalPostgres.enable | bool | `false` | Enable external PostgreSQL instead of MySQL. Static credentials can be provided via externalPostgres.username / externalPostgres.password below (they will be rendered directly into the ConfigMap). To inject credentials from a Kubernetes Secret instead, set manager.renderConfig: true and provide an entry in manager.extraInitContainers that substitutes placeholders into the rendered config:  manager:   renderConfig: true   extraInitContainers:     - name: inject-pg-credentials       image: busybox:latest       command:         - sh         - -c         - |           sed "s/__PG_USER__/$PG_USER/g; s/__PG_PASSWORD__/$PG_PASSWORD/g" \             /etc/dragonfly-template/manager.yaml > /etc/dragonfly/manager.yaml       env:         - name: PG_USER           valueFrom:             secretKeyRef:               name: my-postgres-secret               key: username         - name: PG_PASSWORD           valueFrom:             secretKeyRef:               name: my-postgres-secret               key: password       volumeMounts:         - name: config           mountPath: /etc/dragonfly-template         - name: config-rendered           mountPath: /etc/dragonfly |
 | externalPostgres.host | string | `nil` | External postgres hostname. |
 | externalPostgres.migrate | bool | `true` | Running GORM migration. |
-| externalPostgres.password | string | `"dragonfly"` | External postgres password. Set to a placeholder (e.g. __PG_PASSWORD__) when using an extraInitContainers to inject credentials from a Secret. |
+| externalPostgres.password | string | `"dragonfly"` | External postgres password. Set to a placeholder (e.g. __PG_PASSWORD__) when manager.renderConfig is enabled and credentials are injected from a Secret. |
 | externalPostgres.port | int | `5432` | External postgres port. |
 | externalPostgres.sslMode | string | `"disable"` | External postgres SSL mode. |
 | externalPostgres.timezone | string | `"UTC"` | External postgres timezone. |
-| externalPostgres.username | string | `"dragonfly"` | External postgres username. Set to a placeholder (e.g. __PG_USER__) when using an extraInitContainers to inject credentials from a Secret. |
+| externalPostgres.username | string | `"dragonfly"` | External postgres username. Set to a placeholder (e.g. __PG_USER__) when manager.renderConfig is enabled and credentials are injected from a Secret. |
 | externalRedis.addrs | list | `["redis.example.com:6379"]` | External redis server addresses. |
 | externalRedis.backendDB | int | `2` | External redis backend db. |
 | externalRedis.brokerDB | int | `1` | External redis broker db. |
@@ -391,6 +391,7 @@ helm delete dragonfly --namespace dragonfly-system
 | manager.podAnnotations | object | `{}` | Pod annotations. |
 | manager.podLabels | object | `{}` | Pod labels. |
 | manager.priorityClassName | string | `""` | Pod priorityClassName. |
+| manager.renderConfig | bool | `false` | When true, mount an emptyDir at /etc/dragonfly instead of the raw ConfigMap. An entry in manager.extraInitContainers is then expected to render the final manager.yaml into that emptyDir (e.g. by reading the raw ConfigMap from an extraVolumeMounts path and substituting credentials pulled from a Kubernetes Secret via env vars). See the externalPostgres section below for an end-to-end example. |
 | manager.replicas | int | `3` | Number of Pods to launch. |
 | manager.resources | object | `{"limits":{"cpu":"8","memory":"16Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits. |
 | manager.restPort | int | `8080` | REST service port. |

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -251,7 +251,7 @@ helm delete dragonfly --namespace dragonfly-system
 | externalMysql.port | int | `3306` | External mysql port. |
 | externalMysql.username | string | `"dragonfly"` | External mysql username. |
 | externalPostgres.database | string | `"manager"` | External postgres database name. |
-| externalPostgres.enable | bool | `false` | Enable external PostgreSQL instead of MySQL. Static credentials can be provided via externalPostgres.username / externalPostgres.password below (they will be rendered directly into the ConfigMap). To inject credentials from a Kubernetes Secret instead, set manager.renderConfig: true and provide an entry in manager.extraInitContainers that substitutes placeholders into the rendered config:  manager:   renderConfig: true   extraInitContainers:     - name: inject-pg-credentials       image: busybox:latest       command:         - sh         - -c         - |           sed "s/__PG_USER__/$PG_USER/g; s/__PG_PASSWORD__/$PG_PASSWORD/g" \             /etc/dragonfly-template/manager.yaml > /etc/dragonfly/manager.yaml       env:         - name: PG_USER           valueFrom:             secretKeyRef:               name: my-postgres-secret               key: username         - name: PG_PASSWORD           valueFrom:             secretKeyRef:               name: my-postgres-secret               key: password       volumeMounts:         - name: config           mountPath: /etc/dragonfly-template         - name: config-rendered           mountPath: /etc/dragonfly |
+| externalPostgres.enable | bool | `false` | Enable external PostgreSQL instead of MySQL. Static credentials can be provided via externalPostgres.username, externalPostgres.password below (they will be rendered directly into the ConfigMap).  To inject credentials from a Kubernetes Secret instead see extraInitContainers |
 | externalPostgres.host | string | `nil` | External postgres hostname. |
 | externalPostgres.migrate | bool | `true` | Running GORM migration. |
 | externalPostgres.password | string | `"dragonfly"` | External postgres password. Set to a placeholder (e.g. __PG_PASSWORD__) when manager.renderConfig is enabled and credentials are injected from a Secret. |
@@ -346,7 +346,7 @@ helm delete dragonfly --namespace dragonfly-system
 | manager.deploymentAnnotations | object | `{}` | Deployment annotations. |
 | manager.enable | bool | `true` | Enable manager. |
 | manager.extraEnvVars | list | `[]` | Extra environment variables for pod. |
-| manager.extraInitContainers | list | `[]` | Extra init containers for manager. |
+| manager.extraInitContainers | list | `[]` | Extra init containers for manager. To inject credentials from a Kubernetes Secret, set manager.renderConfig: true and provide an entry in manager.extraInitContainers that substitutes placeholders into the rendered config:  manager:   renderConfig: true   extraInitContainers:     - name: inject-pg-credentials       image: busybox:latest       command:         - sh         - -c         - |           sed "s/__PG_USER__/$PG_USER/g; s/__PG_PASSWORD__/$PG_PASSWORD/g" \             /etc/dragonfly-template/manager.yaml > /etc/dragonfly/manager.yaml       env:         - name: PG_USER           valueFrom:             secretKeyRef:               name: my-postgres-secret               key: username         - name: PG_PASSWORD           valueFrom:             secretKeyRef:               name: my-postgres-secret               key: password       volumeMounts:         - name: config           mountPath: /etc/dragonfly-template         - name: config-rendered           mountPath: /etc/dragonfly |
 | manager.extraVolumeMounts | list | `[{"mountPath":"/var/log/dragonfly/manager","name":"logs"}]` | Extra volumeMounts for manager. |
 | manager.extraVolumes | list | `[{"emptyDir":{},"name":"logs"}]` | Extra volumes for manager. |
 | manager.fullnameOverride | string | `""` | Override manager fullname. |
@@ -391,7 +391,7 @@ helm delete dragonfly --namespace dragonfly-system
 | manager.podAnnotations | object | `{}` | Pod annotations. |
 | manager.podLabels | object | `{}` | Pod labels. |
 | manager.priorityClassName | string | `""` | Pod priorityClassName. |
-| manager.renderConfig | bool | `false` | When true, mount an emptyDir at /etc/dragonfly instead of the raw ConfigMap. An entry in manager.extraInitContainers is then expected to render the final manager.yaml into that emptyDir (e.g. by reading the raw ConfigMap from an extraVolumeMounts path and substituting credentials pulled from a Kubernetes Secret via env vars). See the externalPostgres section below for an end-to-end example. |
+| manager.renderConfig | bool | `false` | When true, mount an emptyDir at /etc/dragonfly instead of the raw ConfigMap. An entry in manager.extraInitContainers is then expected to render the final manager.yaml into that emptyDir (e.g. by reading the raw ConfigMap from an extraVolumeMounts path and substituting credentials pulled from a Kubernetes Secret via env vars). See below for an example. |
 | manager.replicas | int | `3` | Number of Pods to launch. |
 | manager.resources | object | `{"limits":{"cpu":"8","memory":"16Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits. |
 | manager.restPort | int | `8080` | REST service port. |

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -251,7 +251,7 @@ helm delete dragonfly --namespace dragonfly-system
 | externalMysql.port | int | `3306` | External mysql port. |
 | externalMysql.username | string | `"dragonfly"` | External mysql username. |
 | externalPostgres.database | string | `"manager"` | External postgres database name. |
-| externalPostgres.enable | bool | `false` | Enable external PostgreSQL instead of MySQL. Static credentials can be provided via externalPostgres.username, externalPostgres.password below (they will be rendered directly into the ConfigMap).  To inject credentials from a Kubernetes Secret instead see extraInitContainers |
+| externalPostgres.enable | bool | `false` | Enable external PostgreSQL instead of MySQL. Static credentials can be provided via externalPostgres.username, externalPostgres.password below (they will be rendered directly into the ConfigMap). To inject credentials from a Kubernetes Secret instead see extraInitContainers |
 | externalPostgres.host | string | `nil` | External postgres hostname. |
 | externalPostgres.migrate | bool | `true` | Running GORM migration. |
 | externalPostgres.password | string | `"dragonfly"` | External postgres password. Set to a placeholder (e.g. __PG_PASSWORD__) when manager.renderConfig is enabled and credentials are injected from a Secret. |

--- a/charts/dragonfly/templates/manager/manager-configmap.yaml
+++ b/charts/dragonfly/templates/manager/manager-configmap.yaml
@@ -41,6 +41,19 @@ data:
     auth:
 {{ toYaml .Values.manager.config.auth | indent 6 }}
     database:
+      {{- if .Values.externalPostgres.enable }}
+      type: postgres
+      postgres:
+        user: {{ .Values.externalPostgres.username }}
+        password: {{ .Values.externalPostgres.password }}
+        host: {{ .Values.externalPostgres.host }}
+        port: {{ .Values.externalPostgres.port }}
+        dbname: {{ .Values.externalPostgres.database }}
+        sslMode: {{ .Values.externalPostgres.sslMode }}
+        timezone: {{ .Values.externalPostgres.timezone }}
+        migrate: {{ .Values.externalPostgres.migrate }}
+      {{- else }}
+      type: mysql
       mysql:
         {{- if and .Values.mysql.enable (empty .Values.externalMysql.host)}}
         user: {{ .Values.mysql.auth.username }}
@@ -57,6 +70,7 @@ data:
         dbname: {{ .Values.externalMysql.database }}
         migrate: {{ .Values.externalMysql.migrate }}
         {{- end }}
+      {{- end }}
       redis:
         {{- if .Values.redis.enable }}
         addrs:

--- a/charts/dragonfly/templates/manager/manager-deployment.yaml
+++ b/charts/dragonfly/templates/manager/manager-deployment.yaml
@@ -112,7 +112,7 @@ spec:
           protocol: TCP
         {{- end }}
         volumeMounts:
-        - name: {{ if .Values.externalPostgres.enable }}config-rendered{{ else }}config{{ end }}
+        - name: {{ if .Values.manager.renderConfig }}config-rendered{{ else }}config{{ end }}
           mountPath: "/etc/dragonfly"
         {{- if .Values.manager.extraVolumeMounts }}
         {{- toYaml .Values.manager.extraVolumeMounts | nindent 8 }}
@@ -138,7 +138,7 @@ spec:
           items:
           - key: manager.yaml
             path: manager.yaml
-      {{- if .Values.externalPostgres.enable }}
+      {{- if .Values.manager.renderConfig }}
       - name: config-rendered
         emptyDir: {}
       {{- end }}

--- a/charts/dragonfly/templates/manager/manager-deployment.yaml
+++ b/charts/dragonfly/templates/manager/manager-deployment.yaml
@@ -66,7 +66,7 @@ spec:
       hostAliases:
 {{ toYaml .Values.manager.hostAliases | indent 8 }}
       {{- end }}
-      {{- if or .Values.redis.enable .Values.mysql.enable }}
+      {{- if or .Values.redis.enable .Values.mysql.enable .Values.manager.extraInitContainers }}
       initContainers:
       {{- if .Values.redis.enable }}
       - name: wait-for-redis
@@ -83,6 +83,9 @@ spec:
         command: ['sh', '-c', 'until nslookup {{ .Release.Name }}-{{ default "mysql" .Values.mysql.fullname }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }} && nc -vz {{ .Release.Name }}-{{ default "mysql" .Values.mysql.fullname }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }} {{ .Values.mysql.primary.service.port }}; do echo waiting for mysql; sleep 2; done;']
         resources:
 {{ toYaml .Values.manager.initContainer.resources | indent 10 }}
+      {{- end }}
+      {{- if .Values.manager.extraInitContainers }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.manager.extraInitContainers "context" $) | nindent 6 }}
       {{- end }}
       {{- end }}
       containers:
@@ -109,7 +112,7 @@ spec:
           protocol: TCP
         {{- end }}
         volumeMounts:
-        - name: config
+        - name: {{ if .Values.externalPostgres.enable }}config-rendered{{ else }}config{{ end }}
           mountPath: "/etc/dragonfly"
         {{- if .Values.manager.extraVolumeMounts }}
         {{- toYaml .Values.manager.extraVolumeMounts | nindent 8 }}
@@ -135,6 +138,10 @@ spec:
           items:
           - key: manager.yaml
             path: manager.yaml
+      {{- if .Values.externalPostgres.enable }}
+      - name: config-rendered
+        emptyDir: {}
+      {{- end }}
       {{- if .Values.manager.extraVolumes }}
       {{- toYaml .Values.manager.extraVolumes | nindent 6 }}
       {{- end }}

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -1893,7 +1893,7 @@ externalMysql:
 
 externalPostgres:
   # -- Enable external PostgreSQL instead of MySQL.
-  # Static credentials can be provided via externalPostgres.username, externalPostgres.password below (they will be rendered directly into the ConfigMap). 
+  # Static credentials can be provided via externalPostgres.username, externalPostgres.password below (they will be rendered directly into the ConfigMap).
   # To inject credentials from a Kubernetes Secret instead see extraInitContainers
   enable: false
   # -- Running GORM migration.

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -78,6 +78,8 @@ manager:
   deploymentAnnotations: {}
   # --  Extra environment variables for pod.
   extraEnvVars: []
+  # -- Extra init containers for manager.
+  extraInitContainers: []
   # -- Extra volumes for manager.
   extraVolumes:
     - name: logs
@@ -1851,6 +1853,58 @@ externalMysql:
   database: manager
   # -- External mysql port.
   port: 3306
+
+externalPostgres:
+  # -- Enable external PostgreSQL instead of MySQL.
+  # When enabled, the manager mounts a config-rendered emptyDir instead of the
+  # ConfigMap directly. Use manager.extraInitContainers to copy and patch the
+  # config (e.g. inject credentials from a Kubernetes Secret):
+  #
+  # manager:
+  #   extraInitContainers:
+  #     - name: inject-pg-credentials
+  #       image: busybox:latest
+  #       command:
+  #         - sh
+  #         - -c
+  #         - |
+  #           sed "s/__PG_USER__/$PG_USER/g; s/__PG_PASSWORD__/$PG_PASSWORD/g" \
+  #             /etc/dragonfly-template/manager.yaml > /etc/dragonfly/manager.yaml
+  #       env:
+  #         - name: PG_USER
+  #           valueFrom:
+  #             secretKeyRef:
+  #               name: my-postgres-secret
+  #               key: username
+  #         - name: PG_PASSWORD
+  #           valueFrom:
+  #             secretKeyRef:
+  #               name: my-postgres-secret
+  #               key: password
+  #       volumeMounts:
+  #         - name: config
+  #           mountPath: /etc/dragonfly-template
+  #         - name: config-rendered
+  #           mountPath: /etc/dragonfly
+  enable: false
+  # -- Running GORM migration.
+  migrate: true
+  # -- External postgres hostname.
+  host:
+  # -- External postgres username. Set to a placeholder (e.g. __PG_USER__) when
+  # using an extraInitContainers to inject credentials from a Secret.
+  username: dragonfly
+  # -- External postgres password. Set to a placeholder (e.g. __PG_PASSWORD__) when
+  # using an extraInitContainers to inject credentials from a Secret.
+  password: dragonfly
+  # -- External postgres database name.
+  database: manager
+  # -- External postgres port.
+  port: 5432
+  # -- External postgres SSL mode.
+  sslMode: disable
+  # -- External postgres timezone.
+  timezone: UTC
 
 redis:
   # -- Enable redis cluster with docker container.

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -80,6 +80,13 @@ manager:
   extraEnvVars: []
   # -- Extra init containers for manager.
   extraInitContainers: []
+  # -- When true, mount an emptyDir at /etc/dragonfly instead of the raw
+  # ConfigMap. An entry in manager.extraInitContainers is then expected to
+  # render the final manager.yaml into that emptyDir (e.g. by reading the raw
+  # ConfigMap from an extraVolumeMounts path and substituting credentials
+  # pulled from a Kubernetes Secret via env vars). See the externalPostgres
+  # section below for an end-to-end example.
+  renderConfig: false
   # -- Extra volumes for manager.
   extraVolumes:
     - name: logs
@@ -1856,11 +1863,15 @@ externalMysql:
 
 externalPostgres:
   # -- Enable external PostgreSQL instead of MySQL.
-  # When enabled, the manager mounts a config-rendered emptyDir instead of the
-  # ConfigMap directly. Use manager.extraInitContainers to copy and patch the
-  # config (e.g. inject credentials from a Kubernetes Secret):
+  # Static credentials can be provided via externalPostgres.username /
+  # externalPostgres.password below (they will be rendered directly into the
+  # ConfigMap). To inject credentials from a Kubernetes Secret instead, set
+  # manager.renderConfig: true and provide an entry in
+  # manager.extraInitContainers that substitutes placeholders into the
+  # rendered config:
   #
   # manager:
+  #   renderConfig: true
   #   extraInitContainers:
   #     - name: inject-pg-credentials
   #       image: busybox:latest
@@ -1892,10 +1903,10 @@ externalPostgres:
   # -- External postgres hostname.
   host:
   # -- External postgres username. Set to a placeholder (e.g. __PG_USER__) when
-  # using an extraInitContainers to inject credentials from a Secret.
+  # manager.renderConfig is enabled and credentials are injected from a Secret.
   username: dragonfly
   # -- External postgres password. Set to a placeholder (e.g. __PG_PASSWORD__) when
-  # using an extraInitContainers to inject credentials from a Secret.
+  # manager.renderConfig is enabled and credentials are injected from a Secret.
   password: dragonfly
   # -- External postgres database name.
   database: manager

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -82,8 +82,7 @@ manager:
   # ConfigMap. An entry in manager.extraInitContainers is then expected to
   # render the final manager.yaml into that emptyDir (e.g. by reading the raw
   # ConfigMap from an extraVolumeMounts path and substituting credentials
-  # pulled from a Kubernetes Secret via env vars). See the externalPostgres
-  # section below for an end-to-end example.
+  # pulled from a Kubernetes Secret via env vars). See below for an example.
   renderConfig: false
   # -- Extra init containers for manager.
   # To inject credentials from a Kubernetes Secret, set

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -78,8 +78,6 @@ manager:
   deploymentAnnotations: {}
   # --  Extra environment variables for pod.
   extraEnvVars: []
-  # -- Extra init containers for manager.
-  extraInitContainers: []
   # -- When true, mount an emptyDir at /etc/dragonfly instead of the raw
   # ConfigMap. An entry in manager.extraInitContainers is then expected to
   # render the final manager.yaml into that emptyDir (e.g. by reading the raw
@@ -87,6 +85,39 @@ manager:
   # pulled from a Kubernetes Secret via env vars). See the externalPostgres
   # section below for an end-to-end example.
   renderConfig: false
+  # -- Extra init containers for manager.
+  # To inject credentials from a Kubernetes Secret, set
+  # manager.renderConfig: true and provide an entry in manager.extraInitContainers
+  # that substitutes placeholders into the rendered config:
+  #
+  # manager:
+  #   renderConfig: true
+  #   extraInitContainers:
+  #     - name: inject-pg-credentials
+  #       image: busybox:latest
+  #       command:
+  #         - sh
+  #         - -c
+  #         - |
+  #           sed "s/__PG_USER__/$PG_USER/g; s/__PG_PASSWORD__/$PG_PASSWORD/g" \
+  #             /etc/dragonfly-template/manager.yaml > /etc/dragonfly/manager.yaml
+  #       env:
+  #         - name: PG_USER
+  #           valueFrom:
+  #             secretKeyRef:
+  #               name: my-postgres-secret
+  #               key: username
+  #         - name: PG_PASSWORD
+  #           valueFrom:
+  #             secretKeyRef:
+  #               name: my-postgres-secret
+  #               key: password
+  #       volumeMounts:
+  #         - name: config
+  #           mountPath: /etc/dragonfly-template
+  #         - name: config-rendered
+  #           mountPath: /etc/dragonfly
+  extraInitContainers: []
   # -- Extra volumes for manager.
   extraVolumes:
     - name: logs
@@ -1863,40 +1894,8 @@ externalMysql:
 
 externalPostgres:
   # -- Enable external PostgreSQL instead of MySQL.
-  # Static credentials can be provided via externalPostgres.username /
-  # externalPostgres.password below (they will be rendered directly into the
-  # ConfigMap). To inject credentials from a Kubernetes Secret instead, set
-  # manager.renderConfig: true and provide an entry in
-  # manager.extraInitContainers that substitutes placeholders into the
-  # rendered config:
-  #
-  # manager:
-  #   renderConfig: true
-  #   extraInitContainers:
-  #     - name: inject-pg-credentials
-  #       image: busybox:latest
-  #       command:
-  #         - sh
-  #         - -c
-  #         - |
-  #           sed "s/__PG_USER__/$PG_USER/g; s/__PG_PASSWORD__/$PG_PASSWORD/g" \
-  #             /etc/dragonfly-template/manager.yaml > /etc/dragonfly/manager.yaml
-  #       env:
-  #         - name: PG_USER
-  #           valueFrom:
-  #             secretKeyRef:
-  #               name: my-postgres-secret
-  #               key: username
-  #         - name: PG_PASSWORD
-  #           valueFrom:
-  #             secretKeyRef:
-  #               name: my-postgres-secret
-  #               key: password
-  #       volumeMounts:
-  #         - name: config
-  #           mountPath: /etc/dragonfly-template
-  #         - name: config-rendered
-  #           mountPath: /etc/dragonfly
+  # Static credentials can be provided via externalPostgres.username, externalPostgres.password below (they will be rendered directly into the ConfigMap). 
+  # To inject credentials from a Kubernetes Secret instead see extraInitContainers
   enable: false
   # -- Running GORM migration.
   migrate: true


### PR DESCRIPTION
## Summary

The Dragonfly manager application has supported PostgreSQL since dragonflyoss/dragonfly#1459, but the Helm chart only renders MySQL configuration. This adds PostgreSQL support to the chart.

## Changes

### `values.yaml`
- New `externalPostgres` section: `enable`, `host`, `port`, `database`, `username`, `password`, `sslMode`, `timezone`, `migrate`
- New `manager.extraInitContainers: []` — generic escape hatch for additional init containers
- New `manager.renderConfig: false` — opt-in flag that swaps the `/etc/dragonfly` mount from the raw ConfigMap to an emptyDir, so a user-supplied init container can render the final `manager.yaml` (e.g. by substituting credentials pulled from a Kubernetes Secret)
- Commented-out example in the `externalPostgres` section showing how to combine `renderConfig: true` + an init container to inject credentials from a Secret

### `manager-configmap.yaml`
- Adds `database.type` field (`postgres` when enabled, `mysql` otherwise)
- Renders `database.postgres` block when `externalPostgres.enable` is true
- `mysql` block only rendered when postgres is disabled

### `manager-deployment.yaml`
- Adds `manager.extraInitContainers` support via `common.tplvalues.render`
- When `manager.renderConfig` is true, mounts a `config-rendered` emptyDir at `/etc/dragonfly` instead of the raw ConfigMap, and declares that emptyDir volume. The user's `extraInitContainers` entry is expected to read the raw ConfigMap (from an `extraVolumeMounts` path) and write the rendered `manager.yaml` to `/etc/dragonfly/manager.yaml`.
- Default (`renderConfig: false`): manager mounts the ConfigMap directly, `extraInitContainers` stays a pure escape hatch with no volume side effects — static credentials in `values.yaml` work out of the box for both `externalPostgres` and `externalMysql`.

## Usage

### Direct credentials
```yaml
mysql:
  enable: false
externalPostgres:
  enable: true
  host: my-postgres-host
  username: dragonfly
  password: mypassword
  database: manager
```

### Credentials from Kubernetes Secret
```yaml
mysql:
  enable: false
externalPostgres:
  enable: true
  host: my-postgres-host
  database: manager
  username: __PG_USER__
  password: __PG_PASSWORD__
manager:
  renderConfig: true
  extraInitContainers:
    - name: inject-pg-credentials
      image: busybox:latest
      command: ["sh", "-c", "sed 's/__PG_USER__/$PG_USER/g; s/__PG_PASSWORD__/$PG_PASSWORD/g' /etc/dragonfly-template/manager.yaml > /etc/dragonfly/manager.yaml"]
      env:
        - name: PG_USER
          valueFrom:
            secretKeyRef:
              name: my-postgres-secret
              key: username
        - name: PG_PASSWORD
          valueFrom:
            secretKeyRef:
              name: my-postgres-secret
              key: password
      volumeMounts:
        - name: config
          mountPath: /etc/dragonfly-template
        - name: config-rendered
          mountPath: /etc/dragonfly
```

## Follow-up

A more ergonomic `externalPostgres.existingSecret` pattern (chart-shipped init container that does the substitution automatically) is a natural follow-up and will land in a separate PR once this one merges. That avoids bloating this PR further and keeps the review focused on the core `externalPostgres` + `renderConfig` plumbing.