### PR TITLE
feat: add hostPort support and optional wait-for-scheduler

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.6.23
+version: 1.6.24
 appVersion: 2.4.4-rc.1
 keywords:
   - dragonfly
@@ -27,9 +27,8 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Bump dragonfly version to v2.4.4-rc.1.
-    - Bump client version to v1.3.6.
-    - Add proxyAllRegistries configuration to support containerd to pull images.
+    - Add hostPort support for client DaemonSet when hostNetwork is disabled.
+    - Add client.waitForScheduler toggle.
 
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.7.8
+version: 1.7.9
 appVersion: 2.5.1
 keywords:
   - dragonfly

--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -27,6 +27,8 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
+    - Add hostPort support for client DaemonSet when hostNetwork is disabled.
+    - Add client.waitForScheduler toggle.
     - Add optional privileged sysctl init container for client and seed client.
     - Declare client and seed client affinity values.
     - Fix client daemonset annotations misspelled as statefulset annotations.

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -240,6 +240,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.terminationGracePeriodSeconds | string | `nil` | Pod terminationGracePeriodSeconds. |
 | client.tolerations | list | `[]` | List of node taints to tolerate. |
 | client.updateStrategy | object | `{"rollingUpdate":{"maxSurge":0,"maxUnavailable":20},"type":"RollingUpdate"}` | Update strategy for replicas. |
+| client.waitForScheduler | bool | `true` | Wait for scheduler to be ready before starting client. Disable on clusters where hostNetwork pods cannot reach ClusterIP services (e.g. Cilium VXLAN tunnel mode). |
 | clusterDomain | string | `"cluster.local"` | Install application cluster domain. |
 | externalManager.grpcPort | int | `65003` | External GRPC service port. |
 | externalManager.host | string | `nil` | External manager hostname. |

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -235,6 +235,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.podAnnotations | object | `{}` | Pod annotations. |
 | client.podLabels | object | `{}` | Pod labels. |
 | client.priorityClassName | string | `""` | Pod priorityClassName. |
+| client.proxy.server.ip | string | `"127.0.0.1"` | When hostNetwork is false, the host IP to bind the proxy hostPort to. Defaults to 127.0.0.1 so the HTTP proxy is only reachable from runtimes on the same node (e.g. containerd). Set to "0.0.0.0" to bind all node interfaces. |
 | client.resources | object | `{"limits":{"cpu":"4","memory":"8Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits. |
 | client.statefulsetAnnotations | object | `{}` | Statefulset annotations. |
 | client.terminationGracePeriodSeconds | string | `nil` | Pod terminationGracePeriodSeconds. |

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -253,6 +253,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.podAnnotations | object | `{}` | Pod annotations. |
 | client.podLabels | object | `{}` | Pod labels. |
 | client.priorityClassName | string | `""` | Pod priorityClassName. |
+| client.proxy.server.ip | string | `"127.0.0.1"` | When hostNetwork is false, the host IP to bind the proxy hostPort to. Defaults to 127.0.0.1 so the HTTP proxy is only reachable from runtimes on the same node (e.g. containerd). Set to "0.0.0.0" to bind all node interfaces. |
 | client.resources | object | `{"limits":{"cpu":"4","memory":"8Gi"},"requests":{"cpu":"250m","memory":"512Mi"}}` | Pod resource requests and limits. |
 | client.sysctlInit.enable | bool | `false` | Enable a privileged init container that sets host sysctls, following the pattern of the Elasticsearch and OpenSearch charts. Requires hostNetwork for host-wide network sysctls, and is rejected in PodSecurity `restricted` namespaces. |
 | client.sysctlInit.sysctls | object | `{"net.core.rmem_max":"16777216","net.core.wmem_max":"16777216"}` | Sysctls to set, sized for the socket buffers by default. |

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -259,6 +259,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.terminationGracePeriodSeconds | string | `nil` | Pod terminationGracePeriodSeconds. |
 | client.tolerations | list | `[]` | List of node taints to tolerate. |
 | client.updateStrategy | object | `{"rollingUpdate":{"maxSurge":0,"maxUnavailable":20},"type":"RollingUpdate"}` | Update strategy for replicas. |
+| client.waitForScheduler | bool | `true` | Wait for scheduler to be ready before starting client. Disable on clusters where hostNetwork pods cannot reach ClusterIP services (e.g. Cilium VXLAN tunnel mode). |
 | clusterDomain | string | `"cluster.local"` | Install application cluster domain. |
 | externalManager.grpcPort | int | `65003` | External GRPC service port. |
 | externalManager.host | string | `""` | External manager hostname. |

--- a/charts/dragonfly/templates/client/client-daemonset.yaml
+++ b/charts/dragonfly/templates/client/client-daemonset.yaml
@@ -72,7 +72,7 @@ spec:
 {{ toYaml .Values.client.hostAliases | indent 8 }}
       {{- end }}
       initContainers:
-      {{- if .Values.scheduler.enable }}
+      {{- if and .Values.scheduler.enable .Values.client.waitForScheduler }}
       - name: wait-for-scheduler
         image: {{ template "client.initContainer.image" . }}
         imagePullPolicy: {{ .Values.client.initContainer.image.pullPolicy }}
@@ -167,6 +167,14 @@ spec:
               fieldPath: metadata.name
         ports:
         - containerPort: {{ .Values.client.config.upload.server.port }}
+          {{- if not .Values.client.hostNetwork }}
+          hostPort: {{ .Values.client.config.upload.server.port }}
+          {{- end }}
+          protocol: TCP
+        - containerPort: {{ .Values.client.config.proxy.server.port }}
+          {{- if not .Values.client.hostNetwork }}
+          hostPort: {{ .Values.client.config.proxy.server.port }}
+          {{- end }}
           protocol: TCP
         - containerPort: {{ .Values.client.config.health.server.port }}
           protocol: TCP
@@ -175,8 +183,14 @@ spec:
         - containerPort: {{ .Values.client.config.stats.server.port }}
           protocol: TCP
         - containerPort: {{ .Values.client.config.storage.server.tcpPort }}
+          {{- if not .Values.client.hostNetwork }}
+          hostPort: {{ .Values.client.config.storage.server.tcpPort }}
+          {{- end }}
           protocol: TCP
         - containerPort: {{ .Values.client.config.storage.server.quicPort }}
+          {{- if not .Values.client.hostNetwork }}
+          hostPort: {{ .Values.client.config.storage.server.quicPort }}
+          {{- end }}
           protocol: TCP
         readinessProbe:
           exec:

--- a/charts/dragonfly/templates/client/client-daemonset.yaml
+++ b/charts/dragonfly/templates/client/client-daemonset.yaml
@@ -174,6 +174,7 @@ spec:
         - containerPort: {{ .Values.client.config.proxy.server.port }}
           {{- if not .Values.client.hostNetwork }}
           hostPort: {{ .Values.client.config.proxy.server.port }}
+          hostIP: {{ .Values.client.proxy.server.ip | quote }}
           {{- end }}
           protocol: TCP
         - containerPort: {{ .Values.client.config.health.server.port }}

--- a/charts/dragonfly/templates/client/client-daemonset.yaml
+++ b/charts/dragonfly/templates/client/client-daemonset.yaml
@@ -191,6 +191,7 @@ spec:
         - containerPort: {{ .Values.client.config.proxy.server.port }}
           {{- if not .Values.client.hostNetwork }}
           hostPort: {{ .Values.client.config.proxy.server.port }}
+          hostIP: {{ .Values.client.proxy.server.ip | quote }}
           {{- end }}
           protocol: TCP
         - containerPort: {{ .Values.client.config.health.server.port }}

--- a/charts/dragonfly/templates/client/client-daemonset.yaml
+++ b/charts/dragonfly/templates/client/client-daemonset.yaml
@@ -89,7 +89,7 @@ spec:
         resources:
 {{ toYaml .Values.client.initContainer.resources | indent 10 }}
       {{- end }}
-      {{- if .Values.scheduler.enable }}
+      {{- if and .Values.scheduler.enable .Values.client.waitForScheduler }}
       - name: wait-for-scheduler
         image: {{ template "client.initContainer.image" . }}
         imagePullPolicy: {{ .Values.client.initContainer.image.pullPolicy }}
@@ -184,6 +184,14 @@ spec:
               fieldPath: metadata.name
         ports:
         - containerPort: {{ .Values.client.config.upload.server.port }}
+          {{- if not .Values.client.hostNetwork }}
+          hostPort: {{ .Values.client.config.upload.server.port }}
+          {{- end }}
+          protocol: TCP
+        - containerPort: {{ .Values.client.config.proxy.server.port }}
+          {{- if not .Values.client.hostNetwork }}
+          hostPort: {{ .Values.client.config.proxy.server.port }}
+          {{- end }}
           protocol: TCP
         - containerPort: {{ .Values.client.config.health.server.port }}
           protocol: TCP
@@ -192,8 +200,14 @@ spec:
         - containerPort: {{ .Values.client.config.stats.server.port }}
           protocol: TCP
         - containerPort: {{ .Values.client.config.storage.server.tcpPort }}
+          {{- if not .Values.client.hostNetwork }}
+          hostPort: {{ .Values.client.config.storage.server.tcpPort }}
+          {{- end }}
           protocol: TCP
         - containerPort: {{ .Values.client.config.storage.server.quicPort }}
+          {{- if not .Values.client.hostNetwork }}
+          hostPort: {{ .Values.client.config.storage.server.quicPort }}
+          {{- end }}
           protocol: UDP
         {{- if .Values.startupProbe.enable }}
         startupProbe:

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -1222,6 +1222,10 @@ seedClient:
 client:
   # -- Enable client.
   enable: true
+  # -- Wait for scheduler to be ready before starting client.
+  # Disable on clusters where hostNetwork pods cannot reach ClusterIP
+  # services (e.g. Cilium VXLAN tunnel mode).
+  waitForScheduler: true
   # -- Client name.
   name: client
   # -- Override scheduler name.

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -1257,6 +1257,13 @@ client:
   hostIPC: true
   # -- hostNetwork specify if host network should be enabled for peer pod.
   hostNetwork: true
+  proxy:
+    server:
+      # -- When hostNetwork is false, the host IP to bind the proxy hostPort to.
+      # Defaults to 127.0.0.1 so the HTTP proxy is only reachable from runtimes
+      # on the same node (e.g. containerd). Set to "0.0.0.0" to bind all node
+      # interfaces.
+      ip: 127.0.0.1
   # -- Pod resource requests and limits.
   resources:
     requests:

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -1333,6 +1333,10 @@ seedClient:
 client:
   # -- Enable client.
   enable: true
+  # -- Wait for scheduler to be ready before starting client.
+  # Disable on clusters where hostNetwork pods cannot reach ClusterIP
+  # services (e.g. Cilium VXLAN tunnel mode).
+  waitForScheduler: true
   # -- Client name.
   name: client
   # -- Override scheduler name.

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -1368,6 +1368,13 @@ client:
   hostIPC: true
   # -- hostNetwork specify if host network should be enabled for peer pod.
   hostNetwork: true
+  proxy:
+    server:
+      # -- When hostNetwork is false, the host IP to bind the proxy hostPort to.
+      # Defaults to 127.0.0.1 so the HTTP proxy is only reachable from runtimes
+      # on the same node (e.g. containerd). Set to "0.0.0.0" to bind all node
+      # interfaces.
+      ip: 127.0.0.1
   # -- Pod resource requests and limits.
   resources:
     requests:


### PR DESCRIPTION
## Summary

In Cilium VXLAN tunnel mode, `hostNetwork` pods cannot reach pod IPs on remote nodes. The client DaemonSet uses `hostNetwork: true` by default, but discovers scheduler pod IPs from the manager and connects directly. Only local-node schedulers are reachable, breaking P2P distribution.

## Changes

### `templates/client/client-daemonset.yaml`
- Adds conditional `hostPort` to upload (4000), proxy (4001), storage TCP (4005), and storage QUIC (4006) ports when `hostNetwork` is `false`
- Makes `wait-for-scheduler` init container conditional on `client.waitForScheduler` (default `true`)

### `values.yaml`
- Adds `client.waitForScheduler: true`

### How to use

Set `client.hostNetwork: false` in values. The client gets a pod IP so VXLAN encapsulation works for cross-node communication. Containerd still reaches dfdaemon at `127.0.0.1:4001` via the hostPort DNAT rule.

This is the same approach used by [spegel](https://github.com/spegel-org/spegel) for P2P image caching in Cilium environments.