### PR TITLE
feat: (manager) -> support existingConfigSecret for external config manager

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.6.23
+version: 1.6.24
 appVersion: 2.4.4-rc.1
 keywords:
   - dragonfly
@@ -27,9 +27,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Bump dragonfly version to v2.4.4-rc.1.
-    - Bump client version to v1.3.6.
-    - Add proxyAllRegistries configuration to support containerd to pull images.
+    - Add manager.existingConfigSecret option to mount external Secret for config.
 
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -336,6 +336,7 @@ helm delete dragonfly --namespace dragonfly-system
 | manager.config.tracing.protocol | string | `"grpc"` | Protocol specifies the communication protocol for the tracing server. Supported values: "http", "https", "grpc" (default: None). This determines how tracing logs are transmitted to the server. |
 | manager.deploymentAnnotations | object | `{}` | Deployment annotations. |
 | manager.enable | bool | `true` | Enable manager. |
+| manager.existingConfigSecret | string | `""` | Name of an existing Secret containing the full manager.yaml config. When set, the chart will NOT generate a ConfigMap and will mount this Secret at /etc/dragonfly instead. The Secret must have a key named "manager.yaml" containing the complete configuration. This allows you to manage the entire config externally (e.g., via External Secrets Operator, Sealed Secrets, or manual creation). |
 | manager.extraEnvVars | list | `[]` | Extra environment variables for pod. |
 | manager.extraVolumeMounts | list | `[{"mountPath":"/var/log/dragonfly/manager","name":"logs"}]` | Extra volumeMounts for manager. |
 | manager.extraVolumes | list | `[{"emptyDir":{},"name":"logs"}]` | Extra volumes for manager. |

--- a/charts/dragonfly/templates/manager/manager-configmap.yaml
+++ b/charts/dragonfly/templates/manager/manager-configmap.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.manager.enable }}
+{{- if not .Values.manager.existingConfigSecret }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -87,4 +88,5 @@ data:
     pprofPort: {{ .Values.manager.config.pprofPort }}
     tracing:
 {{ toYaml .Values.manager.config.tracing | indent 6 }}
+{{- end }}
 {{- end }}

--- a/charts/dragonfly/templates/manager/manager-deployment.yaml
+++ b/charts/dragonfly/templates/manager/manager-deployment.yaml
@@ -31,7 +31,9 @@ spec:
 {{ toYaml .Values.manager.podLabels | indent 8 }}
         {{- end }}
       annotations:
+        {{- if not .Values.manager.existingConfigSecret }}
         checksum/config: {{ include (print $.Template.BasePath "/manager/manager-configmap.yaml") . | sha256sum }}
+        {{- end }}
       {{- if .Values.manager.podAnnotations }}
 {{ toYaml .Values.manager.podAnnotations | indent 8 }}
       {{- end }}
@@ -130,11 +132,19 @@ spec:
           failureThreshold: 5
       volumes:
       - name: config
+        {{- if .Values.manager.existingConfigSecret }}
+        secret:
+          secretName: {{ .Values.manager.existingConfigSecret }}
+          items:
+          - key: manager.yaml
+            path: manager.yaml
+        {{- else }}
         configMap:
           name: {{ template "dragonfly.manager.fullname" . }}
           items:
           - key: manager.yaml
             path: manager.yaml
+        {{- end }}
       {{- if .Values.manager.extraVolumes }}
       {{- toYaml .Values.manager.extraVolumes | nindent 6 }}
       {{- end }}

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -78,6 +78,13 @@ manager:
   deploymentAnnotations: {}
   # --  Extra environment variables for pod.
   extraEnvVars: []
+  # -- Name of an existing Secret containing the full manager.yaml config.
+  # When set, the chart will NOT generate a ConfigMap and will mount this
+  # Secret at /etc/dragonfly instead. The Secret must have a key named
+  # "manager.yaml" containing the complete configuration.
+  # This allows you to manage the entire config externally (e.g., via
+  # External Secrets Operator, Sealed Secrets, or manual creation).
+  existingConfigSecret: ""
   # -- Extra volumes for manager.
   extraVolumes:
     - name: logs


### PR DESCRIPTION
## Description

This PR adds a new `manager.existingConfigSecret` option that allows users to mount a pre-existing Kubernetes Secret containing the complete `manager.yaml` configuration, instead of using the chart-generated ConfigMap.

### Changes

| File | Change |
|------|--------|
| `values.yaml` | Added `manager.existingConfigSecret` option (default: empty string) |
| `manager-configmap.yaml` | Wrapped ConfigMap creation in conditional - only created when `existingConfigSecret` is not set |
| `manager-deployment.yaml` | Volume mount conditionally uses Secret or ConfigMap; config checksum annotation only added when using generated ConfigMap |

### Usage

```yaml
manager:
  existingConfigSecret: my-manager-config-secret
