### PR TITLE
feat: add configurable startupProbe for all dragonfly components

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.6.23
+version: 1.6.24
 appVersion: 2.4.4-rc.1
 keywords:
   - dragonfly
@@ -27,9 +27,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Bump dragonfly version to v2.4.4-rc.1.
-    - Bump client version to v1.3.6.
-    - Add proxyAllRegistries configuration to support containerd to pull images.
+    - Add configurable startupProbe for manager, scheduler, seedClient, and client (disabled by default).
 
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -236,6 +236,12 @@ helm delete dragonfly --namespace dragonfly-system
 | client.podLabels | object | `{}` | Pod labels. |
 | client.priorityClassName | string | `""` | Pod priorityClassName. |
 | client.resources | object | `{"limits":{"cpu":"4","memory":"8Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits. |
+| client.startupProbe | object | `{"enable":false,"failureThreshold":60,"initialDelaySeconds":0,"periodSeconds":5,"timeoutSeconds":5}` | Startup probe configuration. Allows the container time to start before liveness and readiness probes are evaluated. Useful when dfdaemon warm-up is slow due to peer discovery or cache hydration. |
+| client.startupProbe.enable | bool | `false` | Enable startup probe. |
+| client.startupProbe.failureThreshold | int | `60` | Failure threshold before the container is restarted. Total startup budget = periodSeconds * failureThreshold. |
+| client.startupProbe.initialDelaySeconds | int | `0` | Initial delay before the first probe. |
+| client.startupProbe.periodSeconds | int | `5` | Period (in seconds) between probe attempts. |
+| client.startupProbe.timeoutSeconds | int | `5` | Probe timeout (in seconds). |
 | client.statefulsetAnnotations | object | `{}` | Statefulset annotations. |
 | client.terminationGracePeriodSeconds | string | `nil` | Pod terminationGracePeriodSeconds. |
 | client.tolerations | list | `[]` | List of node taints to tolerate. |
@@ -389,6 +395,12 @@ helm delete dragonfly --namespace dragonfly-system
 | manager.service.labels | object | `{}` | Service labels. |
 | manager.service.nodePort | string | `""` | Service nodePort. |
 | manager.service.type | string | `"ClusterIP"` | Service type. |
+| manager.startupProbe | object | `{"enable":false,"failureThreshold":60,"initialDelaySeconds":0,"periodSeconds":5,"timeoutSeconds":5}` | Startup probe configuration. Allows the container time to start before liveness and readiness probes are evaluated. Useful for slow boots driven by database migrations, peer discovery, or cache hydration. |
+| manager.startupProbe.enable | bool | `false` | Enable startup probe. |
+| manager.startupProbe.failureThreshold | int | `60` | Failure threshold before the container is restarted. Total startup budget = periodSeconds * failureThreshold. |
+| manager.startupProbe.initialDelaySeconds | int | `0` | Initial delay before the first probe. |
+| manager.startupProbe.periodSeconds | int | `5` | Period (in seconds) between probe attempts. |
+| manager.startupProbe.timeoutSeconds | int | `5` | Probe timeout (in seconds). |
 | manager.terminationGracePeriodSeconds | string | `nil` | Pod terminationGracePeriodSeconds. |
 | manager.tolerations | list | `[]` | List of node taints to tolerate. |
 | manager.updateStrategy | object | `{"type":"RollingUpdate"}` | Update strategy for replicas. |
@@ -489,6 +501,12 @@ helm delete dragonfly --namespace dragonfly-system
 | scheduler.service.labels | object | `{}` | Service labels. |
 | scheduler.service.nodePort | string | `""` | Service nodePort. |
 | scheduler.service.type | string | `"ClusterIP"` | Service type. |
+| scheduler.startupProbe | object | `{"enable":false,"failureThreshold":60,"initialDelaySeconds":0,"periodSeconds":5,"timeoutSeconds":5}` | Startup probe configuration. Allows the container time to start before liveness and readiness probes are evaluated. Useful when scheduler boot is slowed by manager registration or peer discovery. |
+| scheduler.startupProbe.enable | bool | `false` | Enable startup probe. |
+| scheduler.startupProbe.failureThreshold | int | `60` | Failure threshold before the container is restarted. Total startup budget = periodSeconds * failureThreshold. |
+| scheduler.startupProbe.initialDelaySeconds | int | `0` | Initial delay before the first probe. |
+| scheduler.startupProbe.periodSeconds | int | `5` | Period (in seconds) between probe attempts. |
+| scheduler.startupProbe.timeoutSeconds | int | `5` | Probe timeout (in seconds). |
 | scheduler.statefulsetAnnotations | object | `{}` | Statefulset annotations. |
 | scheduler.terminationGracePeriodSeconds | string | `nil` | Pod terminationGracePeriodSeconds. |
 | scheduler.tolerations | list | `[]` | List of node taints to tolerate. |
@@ -599,6 +617,12 @@ helm delete dragonfly --namespace dragonfly-system
 | seedClient.service.labels | object | `{}` | Service labels. |
 | seedClient.service.nodePort | string | `""` | Service nodePort. |
 | seedClient.service.type | string | `"ClusterIP"` | Service type. |
+| seedClient.startupProbe | object | `{"enable":false,"failureThreshold":60,"initialDelaySeconds":0,"periodSeconds":5,"timeoutSeconds":5}` | Startup probe configuration. Allows the container time to start before liveness and readiness probes are evaluated. Useful when dfdaemon warm-up is slow due to peer discovery or cache hydration. |
+| seedClient.startupProbe.enable | bool | `false` | Enable startup probe. |
+| seedClient.startupProbe.failureThreshold | int | `60` | Failure threshold before the container is restarted. Total startup budget = periodSeconds * failureThreshold. |
+| seedClient.startupProbe.initialDelaySeconds | int | `0` | Initial delay before the first probe. |
+| seedClient.startupProbe.periodSeconds | int | `5` | Period (in seconds) between probe attempts. |
+| seedClient.startupProbe.timeoutSeconds | int | `5` | Probe timeout (in seconds). |
 | seedClient.statefulsetAnnotations | object | `{}` | Statefulset annotations. |
 | seedClient.terminationGracePeriodSeconds | string | `nil` | Pod terminationGracePeriodSeconds. |
 | seedClient.tolerations | list | `[]` | List of node taints to tolerate. |

--- a/charts/dragonfly/templates/client/client-daemonset.yaml
+++ b/charts/dragonfly/templates/client/client-daemonset.yaml
@@ -192,6 +192,15 @@ spec:
           periodSeconds: 30
           timeoutSeconds: 10
           failureThreshold: 5
+        {{- if .Values.client.startupProbe.enable }}
+        startupProbe:
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=unix://{{ .Values.client.config.download.server.socketPath }}", "-connect-timeout=5s", "-rpc-timeout=5s"]
+          initialDelaySeconds: {{ .Values.client.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.client.startupProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.client.startupProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.client.startupProbe.failureThreshold }}
+        {{- end }}
         volumeMounts:
         - name: config
           mountPath: "/etc/dragonfly"

--- a/charts/dragonfly/templates/manager/manager-deployment.yaml
+++ b/charts/dragonfly/templates/manager/manager-deployment.yaml
@@ -128,6 +128,15 @@ spec:
           periodSeconds: 15
           timeoutSeconds: 10
           failureThreshold: 5
+        {{- if .Values.manager.startupProbe.enable }}
+        startupProbe:
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.manager.grpcPort }}", "-connect-timeout=5s", "-rpc-timeout=5s"]
+          initialDelaySeconds: {{ .Values.manager.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.manager.startupProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.manager.startupProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.manager.startupProbe.failureThreshold }}
+        {{- end }}
       volumes:
       - name: config
         configMap:

--- a/charts/dragonfly/templates/scheduler/scheduler-statefulset.yaml
+++ b/charts/dragonfly/templates/scheduler/scheduler-statefulset.yaml
@@ -120,6 +120,15 @@ spec:
           periodSeconds: 15
           timeoutSeconds: 10
           failureThreshold: 5
+        {{- if .Values.scheduler.startupProbe.enable }}
+        startupProbe:
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.scheduler.containerPort }}", "-connect-timeout=5s", "-rpc-timeout=5s"]
+          initialDelaySeconds: {{ .Values.scheduler.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.scheduler.startupProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.scheduler.startupProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.scheduler.startupProbe.failureThreshold }}
+        {{- end }}
       volumes:
       - name: config
         configMap:

--- a/charts/dragonfly/templates/seed-client/seed-client-statefulset.yaml
+++ b/charts/dragonfly/templates/seed-client/seed-client-statefulset.yaml
@@ -135,6 +135,15 @@ spec:
           periodSeconds: 30
           timeoutSeconds: 10
           failureThreshold: 5
+        {{- if .Values.seedClient.startupProbe.enable }}
+        startupProbe:
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=unix://{{ .Values.seedClient.config.download.server.socketPath }}", "-connect-timeout=5s", "-rpc-timeout=5s"]
+          initialDelaySeconds: {{ .Values.seedClient.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.seedClient.startupProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.seedClient.startupProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.seedClient.startupProbe.failureThreshold }}
+        {{- end }}
         volumeMounts:
         - name: config
           mountPath: "/etc/dragonfly"

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -86,6 +86,20 @@ manager:
   extraVolumeMounts:
     - name: logs
       mountPath: /var/log/dragonfly/manager
+  # -- Startup probe configuration. Allows the container time to start before
+  # liveness and readiness probes are evaluated. Useful for slow boots driven
+  # by database migrations, peer discovery, or cache hydration.
+  startupProbe:
+    # -- Enable startup probe.
+    enable: false
+    # -- Initial delay before the first probe.
+    initialDelaySeconds: 0
+    # -- Period (in seconds) between probe attempts.
+    periodSeconds: 5
+    # -- Probe timeout (in seconds).
+    timeoutSeconds: 5
+    # -- Failure threshold before the container is restarted. Total startup budget = periodSeconds * failureThreshold.
+    failureThreshold: 60
   # -- REST service port.
   restPort: 8080
   # -- GRPC service port.
@@ -394,6 +408,20 @@ scheduler:
   extraVolumeMounts:
     - name: logs
       mountPath: /var/log/dragonfly/scheduler
+  # -- Startup probe configuration. Allows the container time to start before
+  # liveness and readiness probes are evaluated. Useful when scheduler boot is
+  # slowed by manager registration or peer discovery.
+  startupProbe:
+    # -- Enable startup probe.
+    enable: false
+    # -- Initial delay before the first probe.
+    initialDelaySeconds: 0
+    # -- Period (in seconds) between probe attempts.
+    periodSeconds: 5
+    # -- Probe timeout (in seconds).
+    timeoutSeconds: 5
+    # -- Failure threshold before the container is restarted. Total startup budget = periodSeconds * failureThreshold.
+    failureThreshold: 60
   initContainer:
     # -- Pod resource requests and limits.
     resources:
@@ -786,6 +814,20 @@ seedClient:
   extraVolumeMounts:
     - name: logs
       mountPath: /var/log/dragonfly/dfdaemon/
+  # -- Startup probe configuration. Allows the container time to start before
+  # liveness and readiness probes are evaluated. Useful when dfdaemon warm-up
+  # is slow due to peer discovery or cache hydration.
+  startupProbe:
+    # -- Enable startup probe.
+    enable: false
+    # -- Initial delay before the first probe.
+    initialDelaySeconds: 0
+    # -- Period (in seconds) between probe attempts.
+    periodSeconds: 5
+    # -- Probe timeout (in seconds).
+    timeoutSeconds: 5
+    # -- Failure threshold before the container is restarted. Total startup budget = periodSeconds * failureThreshold.
+    failureThreshold: 60
   persistence:
     # -- Enable persistence for seed peer.
     enable: true
@@ -1315,6 +1357,20 @@ client:
       mountPath: /var/lib/dragonfly/
     - name: logs
       mountPath: /var/log/dragonfly/dfdaemon/
+  # -- Startup probe configuration. Allows the container time to start before
+  # liveness and readiness probes are evaluated. Useful when dfdaemon warm-up
+  # is slow due to peer discovery or cache hydration.
+  startupProbe:
+    # -- Enable startup probe.
+    enable: false
+    # -- Initial delay before the first probe.
+    initialDelaySeconds: 0
+    # -- Period (in seconds) between probe attempts.
+    periodSeconds: 5
+    # -- Probe timeout (in seconds).
+    timeoutSeconds: 5
+    # -- Failure threshold before the container is restarted. Total startup budget = periodSeconds * failureThreshold.
+    failureThreshold: 60
   dfinit:
     # -- Enable dfinit to override configuration of container runtime.
     enable: false


### PR DESCRIPTION
## What

Adds optional `startupProbe` to manager, scheduler, seedClient and client. Off by default, no behavior change unless enabled.

## Why

Currently the chart only ships hardcoded readiness/liveness probes. On clusters where dfdaemon boot is slow (peer discovery, cache warm-up), the existing liveness probe can restart the container before it's actually up, or leave it NotReady well after dfdaemon is serving. `startupProbe` is the right fix but there's no way to set one through values today, so users end up patching rendered manifests.

## Example

```yaml
client:
  startupProbe:
    enable: true
    periodSeconds: 2
    failureThreshold: 90
```

Defaults give a 5 minute startup budget when enabled. Reuses the same `grpc_health_probe` exec the existing probes use, so no new image dependencies.

Chart bumped to 1.6.24, README regenerated via helm-docs.

Signed-off-by: Snigdha Aryakumar <snigdha.sambit.ak@gmail.com>