### PR TITLE
feat: add per-component probe overrides

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.6.26
+version: 1.6.27
 appVersion: 2.4.4-rc.1
 keywords:
   - dragonfly

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -217,6 +217,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.initContainer.image.repository | string | `"busybox"` | Image repository. |
 | client.initContainer.image.tag | string | `"latest"` | Image tag. |
 | client.initContainer.resources | object | `{"limits":{"cpu":"2","memory":"4Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits. |
+| client.livenessProbe | object | `{}` | Optional per-component livenessProbe override. Same semantics as `startupProbe` above. |
 | client.maxProcs | string | `""` | maxProcs Limits the number of operating system threads that can execute user-level. Go code simultaneously by setting GOMAXPROCS environment variable, refer to https://golang.org/pkg/runtime. |
 | client.metrics.enable | bool | `true` | Enable client metrics. |
 | client.metrics.prometheusRule.additionalLabels | object | `{}` | Additional labels. |
@@ -236,7 +237,9 @@ helm delete dragonfly --namespace dragonfly-system
 | client.podAnnotations | object | `{}` | Pod annotations. |
 | client.podLabels | object | `{}` | Pod labels. |
 | client.priorityClassName | string | `""` | Pod priorityClassName. |
+| client.readinessProbe | object | `{}` | Optional per-component readinessProbe override. Same semantics as `startupProbe` above. |
 | client.resources | object | `{"limits":{"cpu":"4","memory":"8Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits. |
+| client.startupProbe | object | `{}` | Optional per-component startupProbe override. Fields set here take precedence over the top-level `startupProbe` block; unspecified fields fall back to it. |
 | client.statefulsetAnnotations | object | `{}` | Statefulset annotations. |
 | client.terminationGracePeriodSeconds | string | `nil` | Pod terminationGracePeriodSeconds. |
 | client.tolerations | list | `[]` | List of node taints to tolerate. |
@@ -290,14 +293,17 @@ helm delete dragonfly --namespace dragonfly-system
 | injector.initContainerImage.registry | string | `"docker.io"` | Image registry. |
 | injector.initContainerImage.repository | string | `"dragonflyoss/client"` | Image repository. |
 | injector.initContainerImage.tag | string | `"v1.3.8"` | Image tag. Should align with the version of Dragonfly client and seed client. |
+| injector.livenessProbe | object | `{}` | Optional per-component livenessProbe override. Same semantics as `startupProbe` above. |
 | injector.metrics.enable | bool | `false` | Enable injector metrics. |
 | injector.metrics.service.port | int | `8443` | Metrics service port. |
 | injector.nodeSelector | object | `{}` | Node labels for pod assignment. |
 | injector.podAnnotations | object | `{}` | Pod annotations. |
 | injector.podLabels | object | `{}` | Pod labels. |
 | injector.priorityClassName | string | `""` | Pod priorityClassName. |
+| injector.readinessProbe | object | `{}` | Optional per-component readinessProbe override. Same semantics as `startupProbe` above. |
 | injector.replicas | int | `2` | Number of Pods to launch. |
 | injector.resources | object | `{"limits":{"cpu":"2","memory":"4Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits. |
+| injector.startupProbe | object | `{}` | Optional per-component startupProbe override. Fields set here take precedence over the top-level `startupProbe` block; unspecified fields fall back to it. |
 | injector.terminationGracePeriodSeconds | int | `10` | Pod terminationGracePeriodSeconds. |
 | injector.tolerations | list | `[]` | List of node taints to tolerate. |
 | injector.webhook.failurePolicy | string | `"Ignore"` | failurePolicy defines how unrecognized errors and timeout errors from the admission webhook are handled. Allowed values are "Ignore" or "Fail". |
@@ -369,6 +375,7 @@ helm delete dragonfly --namespace dragonfly-system
 | manager.initContainer.image.repository | string | `"busybox"` | Image repository. |
 | manager.initContainer.image.tag | string | `"latest"` | Image tag. |
 | manager.initContainer.resources | object | `{"limits":{"cpu":"2","memory":"4Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits. |
+| manager.livenessProbe | object | `{}` | Optional per-component livenessProbe override. Same semantics as `startupProbe` above. |
 | manager.maxProcs | string | `""` | maxProcs Limits the number of operating system threads that can execute user-level. Go code simultaneously by setting GOMAXPROCS environment variable, refer to https://golang.org/pkg/runtime. |
 | manager.metrics.enable | bool | `true` | Enable manager metrics. |
 | manager.metrics.prometheusRule.additionalLabels | object | `{}` | Additional labels. |
@@ -388,6 +395,7 @@ helm delete dragonfly --namespace dragonfly-system
 | manager.podAnnotations | object | `{}` | Pod annotations. |
 | manager.podLabels | object | `{}` | Pod labels. |
 | manager.priorityClassName | string | `""` | Pod priorityClassName. |
+| manager.readinessProbe | object | `{}` | Optional per-component readinessProbe override. Same semantics as `startupProbe` above. |
 | manager.replicas | int | `3` | Number of Pods to launch. |
 | manager.resources | object | `{"limits":{"cpu":"8","memory":"16Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits. |
 | manager.restPort | int | `8080` | REST service port. |
@@ -396,6 +404,7 @@ helm delete dragonfly --namespace dragonfly-system
 | manager.service.labels | object | `{}` | Service labels. |
 | manager.service.nodePort | string | `""` | Service nodePort. |
 | manager.service.type | string | `"ClusterIP"` | Service type. |
+| manager.startupProbe | object | `{}` | Optional per-component startupProbe override. Fields set here take precedence over the top-level `startupProbe` block; unspecified fields fall back to it. |
 | manager.terminationGracePeriodSeconds | string | `nil` | Pod terminationGracePeriodSeconds. |
 | manager.tolerations | list | `[]` | List of node taints to tolerate. |
 | manager.updateStrategy | object | `{"type":"RollingUpdate"}` | Update strategy for replicas. |
@@ -475,6 +484,7 @@ helm delete dragonfly --namespace dragonfly-system
 | scheduler.initContainer.image.repository | string | `"busybox"` | Image repository. |
 | scheduler.initContainer.image.tag | string | `"latest"` | Image tag. |
 | scheduler.initContainer.resources | object | `{"limits":{"cpu":"2","memory":"4Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits. |
+| scheduler.livenessProbe | object | `{}` | Optional per-component livenessProbe override. Same semantics as `startupProbe` above. |
 | scheduler.maxProcs | string | `""` | maxProcs Limits the number of operating system threads that can execute user-level. Go code simultaneously by setting GOMAXPROCS environment variable, refer to https://golang.org/pkg/runtime. |
 | scheduler.metrics.enable | bool | `true` | Enable scheduler metrics. |
 | scheduler.metrics.enableHost | bool | `false` | Enable host metrics. |
@@ -495,6 +505,7 @@ helm delete dragonfly --namespace dragonfly-system
 | scheduler.podAnnotations | object | `{}` | Pod annotations. |
 | scheduler.podLabels | object | `{}` | Pod labels. |
 | scheduler.priorityClassName | string | `""` | Pod priorityClassName. |
+| scheduler.readinessProbe | object | `{}` | Optional per-component readinessProbe override. Same semantics as `startupProbe` above. |
 | scheduler.replicas | int | `3` | Number of Pods to launch. |
 | scheduler.resources | object | `{"limits":{"cpu":"8","memory":"16Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits. |
 | scheduler.service.annotations | object | `{}` | Service annotations. |
@@ -502,6 +513,7 @@ helm delete dragonfly --namespace dragonfly-system
 | scheduler.service.labels | object | `{}` | Service labels. |
 | scheduler.service.nodePort | string | `""` | Service nodePort. |
 | scheduler.service.type | string | `"ClusterIP"` | Service type. |
+| scheduler.startupProbe | object | `{}` | Optional per-component startupProbe override. Fields set here take precedence over the top-level `startupProbe` block; unspecified fields fall back to it. |
 | scheduler.statefulsetAnnotations | object | `{}` | Statefulset annotations. |
 | scheduler.terminationGracePeriodSeconds | string | `nil` | Pod terminationGracePeriodSeconds. |
 | scheduler.tolerations | list | `[]` | List of node taints to tolerate. |
@@ -582,6 +594,7 @@ helm delete dragonfly --namespace dragonfly-system
 | seedClient.initContainer.image.repository | string | `"busybox"` | Image repository. |
 | seedClient.initContainer.image.tag | string | `"latest"` | Image tag. |
 | seedClient.initContainer.resources | object | `{"limits":{"cpu":"2","memory":"4Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits. |
+| seedClient.livenessProbe | object | `{}` | Optional per-component livenessProbe override. Same semantics as `startupProbe` above. |
 | seedClient.maxProcs | string | `""` | maxProcs Limits the number of operating system threads that can execute user-level. Go code simultaneously by setting GOMAXPROCS environment variable, refer to https://golang.org/pkg/runtime. |
 | seedClient.metrics.enable | bool | `true` | Enable seed client metrics. |
 | seedClient.metrics.prometheusRule.additionalLabels | object | `{}` | Additional labels. |
@@ -606,6 +619,7 @@ helm delete dragonfly --namespace dragonfly-system
 | seedClient.podAnnotations | object | `{}` | Pod annotations. |
 | seedClient.podLabels | object | `{}` | Pod labels. |
 | seedClient.priorityClassName | string | `""` | Pod priorityClassName. |
+| seedClient.readinessProbe | object | `{}` | Optional per-component readinessProbe override. Same semantics as `startupProbe` above. |
 | seedClient.replicas | int | `3` | Number of Pods to launch. |
 | seedClient.resources | object | `{"limits":{"cpu":"8","memory":"16Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits. |
 | seedClient.service.annotations | object | `{}` | Service annotations. |
@@ -613,6 +627,7 @@ helm delete dragonfly --namespace dragonfly-system
 | seedClient.service.labels | object | `{}` | Service labels. |
 | seedClient.service.nodePort | string | `""` | Service nodePort. |
 | seedClient.service.type | string | `"ClusterIP"` | Service type. |
+| seedClient.startupProbe | object | `{}` | Optional per-component startupProbe override. Fields set here take precedence over the top-level `startupProbe` block; unspecified fields fall back to it. |
 | seedClient.statefulsetAnnotations | object | `{}` | Statefulset annotations. |
 | seedClient.terminationGracePeriodSeconds | string | `nil` | Pod terminationGracePeriodSeconds. |
 | seedClient.tolerations | list | `[]` | List of node taints to tolerate. |

--- a/charts/dragonfly/templates/_helpers.tpl
+++ b/charts/dragonfly/templates/_helpers.tpl
@@ -213,3 +213,25 @@ Return the proper image name (for the injector image)
 {{- define "injector.image" -}}
 {{- include "common.images.image" ( dict "imageRoot" .Values.injector.image "global" .Values.global ) -}}
 {{- end -}}
+
+{{/*
+Compute the effective probe block by merging a per-component override over the global block.
+A component field takes precedence whenever the key is present in the component block,
+including explicit zero values (0, false, ""). Keys absent from the component block fall
+back to the global block.
+Usage: include "dragonfly.probe.effective" (dict "global" .Values.startupProbe "component" .Values.client.startupProbe)
+Returns: YAML for the effective probe block, consumable via fromYaml.
+*/}}
+{{- define "dragonfly.probe.effective" -}}
+{{- $g := .global -}}
+{{- $c := .component | default (dict) -}}
+{{- $r := dict -}}
+{{- range $k, $v := $g -}}
+  {{- if hasKey $c $k -}}
+    {{- $_ := set $r $k (index $c $k) -}}
+  {{- else -}}
+    {{- $_ := set $r $k $v -}}
+  {{- end -}}
+{{- end -}}
+{{- $r | toYaml -}}
+{{- end -}}

--- a/charts/dragonfly/templates/client/client-daemonset.yaml
+++ b/charts/dragonfly/templates/client/client-daemonset.yaml
@@ -178,32 +178,35 @@ spec:
           protocol: TCP
         - containerPort: {{ .Values.client.config.storage.server.quicPort }}
           protocol: TCP
-        {{- if .Values.startupProbe.enable }}
+        {{- $startupProbe := fromYaml (include "dragonfly.probe.effective" (dict "global" .Values.startupProbe "component" .Values.client.startupProbe)) }}
+        {{- if $startupProbe.enable }}
         startupProbe:
           exec:
-            command: ["/bin/grpc_health_probe", "-addr=unix://{{ .Values.client.config.download.server.socketPath }}", "-connect-timeout={{ .Values.startupProbe.timeoutSeconds }}s", "-rpc-timeout={{ .Values.startupProbe.timeoutSeconds }}s"]
-          initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.startupProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.startupProbe.successThreshold }}
-          failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            command: ["/bin/grpc_health_probe", "-addr=unix://{{ .Values.client.config.download.server.socketPath }}", "-connect-timeout={{ $startupProbe.timeoutSeconds }}s", "-rpc-timeout={{ $startupProbe.timeoutSeconds }}s"]
+          initialDelaySeconds: {{ $startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ $startupProbe.periodSeconds }}
+          timeoutSeconds: {{ $startupProbe.timeoutSeconds }}
+          successThreshold: {{ $startupProbe.successThreshold }}
+          failureThreshold: {{ $startupProbe.failureThreshold }}
         {{- end }}
+        {{- $readinessProbe := fromYaml (include "dragonfly.probe.effective" (dict "global" .Values.readinessProbe "component" .Values.client.readinessProbe)) }}
         readinessProbe:
           exec:
-            command: ["/bin/grpc_health_probe", "-addr=unix://{{ .Values.client.config.download.server.socketPath }}", "-connect-timeout={{ .Values.readinessProbe.timeoutSeconds }}s", "-rpc-timeout={{ .Values.readinessProbe.timeoutSeconds }}s"]
-          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.readinessProbe.successThreshold }}
-          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            command: ["/bin/grpc_health_probe", "-addr=unix://{{ .Values.client.config.download.server.socketPath }}", "-connect-timeout={{ $readinessProbe.timeoutSeconds }}s", "-rpc-timeout={{ $readinessProbe.timeoutSeconds }}s"]
+          initialDelaySeconds: {{ $readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ $readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ $readinessProbe.timeoutSeconds }}
+          successThreshold: {{ $readinessProbe.successThreshold }}
+          failureThreshold: {{ $readinessProbe.failureThreshold }}
+        {{- $livenessProbe := fromYaml (include "dragonfly.probe.effective" (dict "global" .Values.livenessProbe "component" .Values.client.livenessProbe)) }}
         livenessProbe:
           exec:
-            command: ["/bin/grpc_health_probe", "-addr=unix://{{ .Values.client.config.download.server.socketPath }}", "-connect-timeout={{ .Values.livenessProbe.timeoutSeconds }}s", "-rpc-timeout={{ .Values.livenessProbe.timeoutSeconds }}s"]
-          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.livenessProbe.successThreshold }}
-          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            command: ["/bin/grpc_health_probe", "-addr=unix://{{ .Values.client.config.download.server.socketPath }}", "-connect-timeout={{ $livenessProbe.timeoutSeconds }}s", "-rpc-timeout={{ $livenessProbe.timeoutSeconds }}s"]
+          initialDelaySeconds: {{ $livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ $livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ $livenessProbe.timeoutSeconds }}
+          successThreshold: {{ $livenessProbe.successThreshold }}
+          failureThreshold: {{ $livenessProbe.failureThreshold }}
         volumeMounts:
         - name: config
           mountPath: "/etc/dragonfly"

--- a/charts/dragonfly/templates/injector/injector-deployment.yaml
+++ b/charts/dragonfly/templates/injector/injector-deployment.yaml
@@ -82,35 +82,38 @@ spec:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
-        {{- if .Values.startupProbe.enable }}
+        {{- $startupProbe := fromYaml (include "dragonfly.probe.effective" (dict "global" .Values.startupProbe "component" .Values.injector.startupProbe)) }}
+        {{- if $startupProbe.enable }}
         startupProbe:
           httpGet:
             path: /readyz
             port: 8081
-          initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.startupProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.startupProbe.successThreshold }}
-          failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          initialDelaySeconds: {{ $startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ $startupProbe.periodSeconds }}
+          timeoutSeconds: {{ $startupProbe.timeoutSeconds }}
+          successThreshold: {{ $startupProbe.successThreshold }}
+          failureThreshold: {{ $startupProbe.failureThreshold }}
         {{- end }}
+        {{- $readinessProbe := fromYaml (include "dragonfly.probe.effective" (dict "global" .Values.readinessProbe "component" .Values.injector.readinessProbe)) }}
         readinessProbe:
           httpGet:
             path: /readyz
             port: 8081
-          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.readinessProbe.successThreshold }}
-          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          initialDelaySeconds: {{ $readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ $readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ $readinessProbe.timeoutSeconds }}
+          successThreshold: {{ $readinessProbe.successThreshold }}
+          failureThreshold: {{ $readinessProbe.failureThreshold }}
+        {{- $livenessProbe := fromYaml (include "dragonfly.probe.effective" (dict "global" .Values.livenessProbe "component" .Values.injector.livenessProbe)) }}
         livenessProbe:
           httpGet:
             path: /healthz
             port: 8081
-          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.livenessProbe.successThreshold }}
-          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          initialDelaySeconds: {{ $livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ $livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ $livenessProbe.timeoutSeconds }}
+          successThreshold: {{ $livenessProbe.successThreshold }}
+          failureThreshold: {{ $livenessProbe.failureThreshold }}
         resources:
 {{ toYaml .Values.injector.resources | indent 10 }}
         {{- if .Values.injector.extraEnvVars }}

--- a/charts/dragonfly/templates/manager/manager-deployment.yaml
+++ b/charts/dragonfly/templates/manager/manager-deployment.yaml
@@ -114,32 +114,35 @@ spec:
         {{- if .Values.manager.extraVolumeMounts }}
         {{- toYaml .Values.manager.extraVolumeMounts | nindent 8 }}
         {{- end }}
-        {{- if .Values.startupProbe.enable }}
+        {{- $startupProbe := fromYaml (include "dragonfly.probe.effective" (dict "global" .Values.startupProbe "component" .Values.manager.startupProbe)) }}
+        {{- if $startupProbe.enable }}
         startupProbe:
           exec:
-            command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.manager.grpcPort }}", "-connect-timeout={{ .Values.startupProbe.timeoutSeconds }}s", "-rpc-timeout={{ .Values.startupProbe.timeoutSeconds }}s"]
-          initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.startupProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.startupProbe.successThreshold }}
-          failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.manager.grpcPort }}", "-connect-timeout={{ $startupProbe.timeoutSeconds }}s", "-rpc-timeout={{ $startupProbe.timeoutSeconds }}s"]
+          initialDelaySeconds: {{ $startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ $startupProbe.periodSeconds }}
+          timeoutSeconds: {{ $startupProbe.timeoutSeconds }}
+          successThreshold: {{ $startupProbe.successThreshold }}
+          failureThreshold: {{ $startupProbe.failureThreshold }}
         {{- end }}
+        {{- $readinessProbe := fromYaml (include "dragonfly.probe.effective" (dict "global" .Values.readinessProbe "component" .Values.manager.readinessProbe)) }}
         readinessProbe:
           exec:
-            command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.manager.grpcPort }}", "-connect-timeout={{ .Values.readinessProbe.timeoutSeconds }}s", "-rpc-timeout={{ .Values.readinessProbe.timeoutSeconds }}s"]
-          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.readinessProbe.successThreshold }}
-          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.manager.grpcPort }}", "-connect-timeout={{ $readinessProbe.timeoutSeconds }}s", "-rpc-timeout={{ $readinessProbe.timeoutSeconds }}s"]
+          initialDelaySeconds: {{ $readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ $readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ $readinessProbe.timeoutSeconds }}
+          successThreshold: {{ $readinessProbe.successThreshold }}
+          failureThreshold: {{ $readinessProbe.failureThreshold }}
+        {{- $livenessProbe := fromYaml (include "dragonfly.probe.effective" (dict "global" .Values.livenessProbe "component" .Values.manager.livenessProbe)) }}
         livenessProbe:
           exec:
-            command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.manager.grpcPort }}", "-connect-timeout={{ .Values.livenessProbe.timeoutSeconds }}s", "-rpc-timeout={{ .Values.livenessProbe.timeoutSeconds }}s"]
-          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.livenessProbe.successThreshold }}
-          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.manager.grpcPort }}", "-connect-timeout={{ $livenessProbe.timeoutSeconds }}s", "-rpc-timeout={{ $livenessProbe.timeoutSeconds }}s"]
+          initialDelaySeconds: {{ $livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ $livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ $livenessProbe.timeoutSeconds }}
+          successThreshold: {{ $livenessProbe.successThreshold }}
+          failureThreshold: {{ $livenessProbe.failureThreshold }}
       volumes:
       - name: config
         configMap:

--- a/charts/dragonfly/templates/scheduler/scheduler-statefulset.yaml
+++ b/charts/dragonfly/templates/scheduler/scheduler-statefulset.yaml
@@ -106,32 +106,35 @@ spec:
         {{- if .Values.scheduler.extraVolumeMounts }}
         {{- toYaml .Values.scheduler.extraVolumeMounts | nindent 8 }}
         {{- end }}
-        {{- if .Values.startupProbe.enable }}
+        {{- $startupProbe := fromYaml (include "dragonfly.probe.effective" (dict "global" .Values.startupProbe "component" .Values.scheduler.startupProbe)) }}
+        {{- if $startupProbe.enable }}
         startupProbe:
           exec:
-            command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.scheduler.containerPort }}", "-connect-timeout={{ .Values.startupProbe.timeoutSeconds }}s", "-rpc-timeout={{ .Values.startupProbe.timeoutSeconds }}s"]
-          initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.startupProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.startupProbe.successThreshold }}
-          failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.scheduler.containerPort }}", "-connect-timeout={{ $startupProbe.timeoutSeconds }}s", "-rpc-timeout={{ $startupProbe.timeoutSeconds }}s"]
+          initialDelaySeconds: {{ $startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ $startupProbe.periodSeconds }}
+          timeoutSeconds: {{ $startupProbe.timeoutSeconds }}
+          successThreshold: {{ $startupProbe.successThreshold }}
+          failureThreshold: {{ $startupProbe.failureThreshold }}
         {{- end }}
+        {{- $readinessProbe := fromYaml (include "dragonfly.probe.effective" (dict "global" .Values.readinessProbe "component" .Values.scheduler.readinessProbe)) }}
         readinessProbe:
           exec:
-            command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.scheduler.containerPort }}", "-connect-timeout={{ .Values.readinessProbe.timeoutSeconds }}s", "-rpc-timeout={{ .Values.readinessProbe.timeoutSeconds }}s"]
-          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.readinessProbe.successThreshold }}
-          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.scheduler.containerPort }}", "-connect-timeout={{ $readinessProbe.timeoutSeconds }}s", "-rpc-timeout={{ $readinessProbe.timeoutSeconds }}s"]
+          initialDelaySeconds: {{ $readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ $readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ $readinessProbe.timeoutSeconds }}
+          successThreshold: {{ $readinessProbe.successThreshold }}
+          failureThreshold: {{ $readinessProbe.failureThreshold }}
+        {{- $livenessProbe := fromYaml (include "dragonfly.probe.effective" (dict "global" .Values.livenessProbe "component" .Values.scheduler.livenessProbe)) }}
         livenessProbe:
           exec:
-            command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.scheduler.containerPort }}", "-connect-timeout={{ .Values.livenessProbe.timeoutSeconds }}s", "-rpc-timeout={{ .Values.livenessProbe.timeoutSeconds }}s"]
-          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.livenessProbe.successThreshold }}
-          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.scheduler.containerPort }}", "-connect-timeout={{ $livenessProbe.timeoutSeconds }}s", "-rpc-timeout={{ $livenessProbe.timeoutSeconds }}s"]
+          initialDelaySeconds: {{ $livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ $livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ $livenessProbe.timeoutSeconds }}
+          successThreshold: {{ $livenessProbe.successThreshold }}
+          failureThreshold: {{ $livenessProbe.failureThreshold }}
       volumes:
       - name: config
         configMap:

--- a/charts/dragonfly/templates/seed-client/seed-client-statefulset.yaml
+++ b/charts/dragonfly/templates/seed-client/seed-client-statefulset.yaml
@@ -121,32 +121,35 @@ spec:
           protocol: TCP
         - containerPort: {{ .Values.seedClient.config.storage.server.quicPort }}
           protocol: TCP
-        {{- if .Values.startupProbe.enable }}
+        {{- $startupProbe := fromYaml (include "dragonfly.probe.effective" (dict "global" .Values.startupProbe "component" .Values.seedClient.startupProbe)) }}
+        {{- if $startupProbe.enable }}
         startupProbe:
           exec:
-            command: ["/bin/grpc_health_probe", "-addr=unix://{{ .Values.seedClient.config.download.server.socketPath }}", "-connect-timeout={{ .Values.startupProbe.timeoutSeconds }}s", "-rpc-timeout={{ .Values.startupProbe.timeoutSeconds }}s"]
-          initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.startupProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.startupProbe.successThreshold }}
-          failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            command: ["/bin/grpc_health_probe", "-addr=unix://{{ .Values.seedClient.config.download.server.socketPath }}", "-connect-timeout={{ $startupProbe.timeoutSeconds }}s", "-rpc-timeout={{ $startupProbe.timeoutSeconds }}s"]
+          initialDelaySeconds: {{ $startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ $startupProbe.periodSeconds }}
+          timeoutSeconds: {{ $startupProbe.timeoutSeconds }}
+          successThreshold: {{ $startupProbe.successThreshold }}
+          failureThreshold: {{ $startupProbe.failureThreshold }}
         {{- end }}
+        {{- $readinessProbe := fromYaml (include "dragonfly.probe.effective" (dict "global" .Values.readinessProbe "component" .Values.seedClient.readinessProbe)) }}
         readinessProbe:
           exec:
-            command: ["/bin/grpc_health_probe", "-addr=unix://{{ .Values.seedClient.config.download.server.socketPath }}", "-connect-timeout={{ .Values.readinessProbe.timeoutSeconds }}s", "-rpc-timeout={{ .Values.readinessProbe.timeoutSeconds }}s"]
-          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.readinessProbe.successThreshold }}
-          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            command: ["/bin/grpc_health_probe", "-addr=unix://{{ .Values.seedClient.config.download.server.socketPath }}", "-connect-timeout={{ $readinessProbe.timeoutSeconds }}s", "-rpc-timeout={{ $readinessProbe.timeoutSeconds }}s"]
+          initialDelaySeconds: {{ $readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ $readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ $readinessProbe.timeoutSeconds }}
+          successThreshold: {{ $readinessProbe.successThreshold }}
+          failureThreshold: {{ $readinessProbe.failureThreshold }}
+        {{- $livenessProbe := fromYaml (include "dragonfly.probe.effective" (dict "global" .Values.livenessProbe "component" .Values.seedClient.livenessProbe)) }}
         livenessProbe:
           exec:
-            command: ["/bin/grpc_health_probe", "-addr=unix://{{ .Values.seedClient.config.download.server.socketPath }}", "-connect-timeout={{ .Values.livenessProbe.timeoutSeconds }}s", "-rpc-timeout={{ .Values.livenessProbe.timeoutSeconds }}s"]
-          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.livenessProbe.successThreshold }}
-          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            command: ["/bin/grpc_health_probe", "-addr=unix://{{ .Values.seedClient.config.download.server.socketPath }}", "-connect-timeout={{ $livenessProbe.timeoutSeconds }}s", "-rpc-timeout={{ $livenessProbe.timeoutSeconds }}s"]
+          initialDelaySeconds: {{ $livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ $livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ $livenessProbe.timeoutSeconds }}
+          successThreshold: {{ $livenessProbe.successThreshold }}
+          failureThreshold: {{ $livenessProbe.failureThreshold }}
         volumeMounts:
         - name: config
           mountPath: "/etc/dragonfly"

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -109,6 +109,12 @@ manager:
   terminationGracePeriodSeconds:
   # -- List of node taints to tolerate.
   tolerations: []
+  # -- Optional per-component startupProbe override. Fields set here take precedence over the top-level `startupProbe` block; unspecified fields fall back to it.
+  startupProbe: {}
+  # -- Optional per-component readinessProbe override. Same semantics as `startupProbe` above.
+  readinessProbe: {}
+  # -- Optional per-component livenessProbe override. Same semantics as `startupProbe` above.
+  livenessProbe: {}
   # -- Pod annotations.
   podAnnotations: {}
   # -- Pod labels.
@@ -416,6 +422,12 @@ scheduler:
   terminationGracePeriodSeconds:
   # -- List of node taints to tolerate.
   tolerations: []
+  # -- Optional per-component startupProbe override. Fields set here take precedence over the top-level `startupProbe` block; unspecified fields fall back to it.
+  startupProbe: {}
+  # -- Optional per-component readinessProbe override. Same semantics as `startupProbe` above.
+  readinessProbe: {}
+  # -- Optional per-component livenessProbe override. Same semantics as `startupProbe` above.
+  livenessProbe: {}
   # -- Pod annotations.
   podAnnotations: {}
   # -- Pod labels.
@@ -790,6 +802,12 @@ seedClient:
   terminationGracePeriodSeconds:
   # -- List of node taints to tolerate.
   tolerations: []
+  # -- Optional per-component startupProbe override. Fields set here take precedence over the top-level `startupProbe` block; unspecified fields fall back to it.
+  startupProbe: {}
+  # -- Optional per-component readinessProbe override. Same semantics as `startupProbe` above.
+  readinessProbe: {}
+  # -- Optional per-component livenessProbe override. Same semantics as `startupProbe` above.
+  livenessProbe: {}
   # -- Pod annotations.
   podAnnotations: {}
   # -- Pod labels.
@@ -1314,6 +1332,12 @@ client:
   terminationGracePeriodSeconds:
   # -- List of node taints to tolerate.
   tolerations: []
+  # -- Optional per-component startupProbe override. Fields set here take precedence over the top-level `startupProbe` block; unspecified fields fall back to it.
+  startupProbe: {}
+  # -- Optional per-component readinessProbe override. Same semantics as `startupProbe` above.
+  readinessProbe: {}
+  # -- Optional per-component livenessProbe override. Same semantics as `startupProbe` above.
+  livenessProbe: {}
   # -- Pod annotations.
   podAnnotations: {}
   # -- Pod labels.
@@ -1974,6 +1998,12 @@ injector:
   terminationGracePeriodSeconds: 10
   # -- List of node taints to tolerate.
   tolerations: []
+  # -- Optional per-component startupProbe override. Fields set here take precedence over the top-level `startupProbe` block; unspecified fields fall back to it.
+  startupProbe: {}
+  # -- Optional per-component readinessProbe override. Same semantics as `startupProbe` above.
+  readinessProbe: {}
+  # -- Optional per-component livenessProbe override. Same semantics as `startupProbe` above.
+  livenessProbe: {}
   # -- Pod affinity.
   affinity: {}
   # -- Pod annotations.


### PR DESCRIPTION
### What

Per-component `startupProbe` / `readinessProbe` / `livenessProbe` override blocks on manager, scheduler, seedClient, client, injector. Component fields win; unset fields fall back to the existing global.

### Why

#501 had per-component startupProbe. #498's squash-merge collapsed it into one global block, not called out in any commit message. One timing fits no component well: seedClient cold-boots in 60-120s and needs slack, manager wants tight liveness. We hit manager liveness flap on cold boot in our clusters today.

### Example

```yaml
# enable startup on slow components only
client:
  startupProbe:
    enable: true
seedClient:
  startupProbe:
    enable: true
    failureThreshold: 90  # ~7.5 min for cold cache hydration
# manager keeps the global default (startup disabled, tight liveness)
```

No override = zero diff vs main (verified by `helm template` byte-diff). Helper uses `hasKey` since sprig `merge` drops explicit zero values. Chart 1.6.26 → 1.6.27, README regenerated.