### PR TITLE
fix: properly render seedClient volumeClaimTemplate annotations

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.7.0
+version: 1.7.1
 appVersion: 2.5.0
 keywords:
   - dragonfly

--- a/charts/dragonfly/templates/seed-client/seed-client-statefulset.yaml
+++ b/charts/dragonfly/templates/seed-client/seed-client-statefulset.yaml
@@ -175,8 +175,9 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: storage
-        {{- range $key, $value := .Values.seedClient.persistence.annotations }}
-          {{ $key }}: {{ $value }}
+        {{- if .Values.seedClient.persistence.annotations }}
+        annotations:
+        {{- toYaml .Values.seedClient.persistence.annotations | nindent 10 }}
         {{- end }}
       spec:
         accessModes:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
1. Add missing `annotations:` line to volumeClaimTemplate annotations template for seed-client statefulset
2. Use `toYaml | nindent` instead of `range` for rendering annotations map

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/dragonflyoss/helm-charts/issues/511


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
There was `annotations:` line missing in the template so rendering failed if annotations are specified. Also this code used a bit different pattern of rendering map - `range` instead of `toYaml` that is used in every other places.
