### PR TITLE
feat(dragonfly): support existingSecret for mysql, redis and jwt credentials

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.7.3
+version: 1.7.4
 appVersion: 2.5.0
 keywords:
   - dragonfly
@@ -27,7 +27,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Add externalRedis TLS client configuration support.
+    - Add existingSecret support for mysql, redis and the manager jwt signing key, so credentials no longer need to be stored in plaintext values.
   artifacthub.io/links: |
     - name: Chart Source
       url: https://github.com/dragonflyoss/helm-charts

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -257,18 +257,23 @@ helm delete dragonfly --namespace dragonfly-system
 | externalManager.host | string | `nil` | External manager hostname. |
 | externalManager.restPort | int | `8080` | External REST service port. |
 | externalMysql.database | string | `"manager"` | External mysql database name. |
+| externalMysql.existingSecret | string | `""` | existingSecret is the name of an existing secret containing the external mysql password. The secret must contain the key defined by existingSecretPasswordKey. When set, it takes precedence over the password field above. |
+| externalMysql.existingSecretPasswordKey | string | `"password"` | existingSecretPasswordKey is the key within existingSecret that holds the external mysql password. |
 | externalMysql.host | string | `nil` | External mysql hostname. |
 | externalMysql.migrate | bool | `true` | Running GORM migration. |
-| externalMysql.password | string | `"dragonfly"` | External mysql password. |
+| externalMysql.password | string | `"dragonfly"` | External mysql password. Ignored when existingSecret is set. |
 | externalMysql.port | int | `3306` | External mysql port. |
 | externalMysql.username | string | `"dragonfly"` | External mysql username. |
 | externalRedis.addrs | list | `["redis.example.com:6379"]` | External redis server addresses. |
 | externalRedis.backendDB | int | `2` | External redis backend db. |
 | externalRedis.brokerDB | int | `1` | External redis broker db. |
 | externalRedis.db | int | `0` | External redis db. |
+| externalRedis.existingSecret | string | `""` | existingSecret is the name of an existing secret containing the external redis password and/or sentinel password. |
+| externalRedis.existingSecretPasswordKey | string | `"password"` | existingSecretPasswordKey is the key within existingSecret that holds the external redis password. |
+| externalRedis.existingSecretSentinelPasswordKey | string | `"sentinel-password"` | existingSecretSentinelPasswordKey is the key within existingSecret that holds the external redis sentinel password. |
 | externalRedis.masterName | string | `""` | External redis sentinel master name. |
-| externalRedis.password | string | `""` | External redis password. |
-| externalRedis.sentinelPassword | string | `""` | External redis sentinel password. |
+| externalRedis.password | string | `""` | External redis password. Ignored when existingSecret is set. |
+| externalRedis.sentinelPassword | string | `""` | External redis sentinel password. Ignored when existingSecret is set. |
 | externalRedis.sentinelUsername | string | `""` | External redis sentinel addresses. |
 | externalRedis.tls | object | `{"caCert":"","cert":"","insecureSkipVerify":false,"key":""}` | TLS client configuration for external redis connection. |
 | externalRedis.tls.caCert | string | `""` | caCert is the CA certificate file path for redis TLS handshake. |
@@ -324,7 +329,9 @@ helm delete dragonfly --namespace dragonfly-system
 | livenessProbe.periodSeconds | int | `10` | Period (in seconds) between probe attempts. |
 | livenessProbe.successThreshold | int | `1` | Success threshold for liveness probe. Must be 1 for liveness probes. |
 | livenessProbe.timeoutSeconds | int | `3` | Probe timeout (in seconds). |
-| manager.config.auth.jwt.key | string | `"ZHJhZ29uZmx5Cg=="` | Key is secret key used for signing, default value is encoded base64 of dragonfly. Please change the key in production. |
+| manager.config.auth.jwt.existingSecret | string | `""` | existingSecret is the name of an existing secret containing the jwt signing key. The secret must contain the key defined by existingSecretKeyKey. When set, it takes precedence over the key field above. |
+| manager.config.auth.jwt.existingSecretKeyKey | string | `"jwt-key"` | existingSecretKeyKey is the key within existingSecret that holds the jwt signing key. |
+| manager.config.auth.jwt.key | string | `"ZHJhZ29uZmx5Cg=="` | Key is secret key used for signing, default value is encoded base64 of dragonfly. Please change the key in production. Ignored when existingSecret is set. |
 | manager.config.auth.jwt.maxRefresh | string | `"48h"` | MaxRefresh field allows clients to refresh their token until MaxRefresh has passed, default duration is two days. |
 | manager.config.auth.jwt.realm | string | `"Dragonfly"` | Realm name to display to the user, default value is Dragonfly. |
 | manager.config.auth.jwt.timeout | string | `"48h"` | Timeout is duration that a jwt token is valid, default duration is two days. |
@@ -416,9 +423,10 @@ helm delete dragonfly --namespace dragonfly-system
 | manager.tolerations | list | `[]` | List of node taints to tolerate. |
 | manager.updateStrategy | object | `{"type":"RollingUpdate"}` | Update strategy for replicas. |
 | mysql.auth.database | string | `"manager"` | Mysql database name. |
+| mysql.auth.existingSecret | string | `""` | existingSecret is the name of an existing secret containing the mysql root and user passwords, under the fixed keys `mysql-root-password` and `mysql-password`. When set, it takes precedence over rootPassword/password above, both for the mysql pod and for the manager's own database connection. |
 | mysql.auth.host | string | `""` | Mysql hostname. |
-| mysql.auth.password | string | `"dragonfly"` | Mysql password. |
-| mysql.auth.rootPassword | string | `"dragonfly-root"` | Mysql root password. |
+| mysql.auth.password | string | `"dragonfly"` | Mysql password. Ignored when existingSecret is set. |
+| mysql.auth.rootPassword | string | `"dragonfly-root"` | Mysql root password. Ignored when existingSecret is set. |
 | mysql.auth.username | string | `"dragonfly"` | Mysql username. |
 | mysql.clusterDomain | string | `"cluster.local"` | Cluster domain. |
 | mysql.enable | bool | `true` | Enable mysql with docker container. |
@@ -434,7 +442,9 @@ helm delete dragonfly --namespace dragonfly-system
 | readinessProbe.successThreshold | int | `1` | Success threshold for readiness probe. The container will be marked as ready after this many consecutive successes. |
 | readinessProbe.timeoutSeconds | int | `3` | Probe timeout (in seconds). |
 | redis.auth.enabled | bool | `true` | Enable password authentication. |
-| redis.auth.password | string | `"dragonfly"` | Redis password. |
+| redis.auth.existingSecret | string | `""` | existingSecret is the name of an existing secret containing the redis password. When set, it takes precedence over password above, both for the redis pod and for the manager/scheduler database connections. |
+| redis.auth.existingSecretPasswordKey | string | `"redis-password"` | existingSecretPasswordKey is the key within existingSecret that holds the redis password. |
+| redis.auth.password | string | `"dragonfly"` | Redis password. Ignored when existingSecret is set. |
 | redis.clusterDomain | string | `"cluster.local"` | Cluster domain. |
 | redis.enable | bool | `true` | Enable redis cluster with docker container. |
 | redis.image.repository | string | `"bitnamilegacy/redis"` |  |

--- a/charts/dragonfly/templates/_helpers.tpl
+++ b/charts/dragonfly/templates/_helpers.tpl
@@ -213,3 +213,48 @@ Return the proper image name (for the injector image)
 {{- define "injector.image" -}}
 {{- include "common.images.image" ( dict "imageRoot" .Values.injector.image "global" .Values.global ) -}}
 {{- end -}}
+
+{{/*
+Placeholder tokens substituted into rendered manager.yaml/scheduler.yaml config files by
+"dragonfly.renderSecretsScript" below. Configmap templates emit one of these tokens, instead of
+the plaintext secret value, whenever the corresponding existingSecret value is configured.
+*/}}
+{{- define "dragonfly.secrets.mysqlPasswordPlaceholder" -}}__DRAGONFLY_MYSQL_PASSWORD__{{- end -}}
+{{- define "dragonfly.secrets.redisPasswordPlaceholder" -}}__DRAGONFLY_REDIS_PASSWORD__{{- end -}}
+{{- define "dragonfly.secrets.redisSentinelPasswordPlaceholder" -}}__DRAGONFLY_REDIS_SENTINEL_PASSWORD__{{- end -}}
+{{- define "dragonfly.secrets.jwtKeyPlaceholder" -}}__DRAGONFLY_JWT_KEY__{{- end -}}
+
+{{/*
+Shell script run by the "render-secrets" initContainer. It copies the config template (mounted
+read-only from a ConfigMap) into a writable emptyDir, then substitutes any placeholder token
+(see above) for the value of its matching environment variable. Config keys that were not backed
+by an existingSecret were rendered as plaintext directly by the ConfigMap template, so their
+placeholder never appears here and the substitution is a no-op for them.
+Placeholders are always emitted quoted (e.g. `password: "__DRAGONFLY_MYSQL_PASSWORD__"`), so a
+value is first escaped for a YAML double-quoted scalar (backslash, then double quote), and the
+result of that is then escaped again for use as a sed replacement (backslash, "/" delimiter, then
+"&"). This lets secrets contain arbitrary characters -- including ":", "#", "\" and "/" -- without
+corrupting the rendered config file. Raw, unescaped newlines within a secret are not supported.
+Usage: {{ include "dragonfly.renderSecretsScript" . | indent 12 }} under a `sh -c |` command.
+*/}}
+{{- define "dragonfly.renderSecretsScript" -}}
+set -eu
+mkdir -p /dragonfly-config
+for f in /dragonfly-config-template/*; do
+  cp "$f" /dragonfly-config/
+done
+render() {
+  placeholder="$1"
+  value="$2"
+  [ -z "$value" ] && return 0
+  yaml_escaped=$(printf '%s' "$value" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
+  sed_escaped=$(printf '%s' "$yaml_escaped" | sed 's/[&/\]/\\&/g')
+  for f in /dragonfly-config/*; do
+    sed -i "s/${placeholder}/${sed_escaped}/g" "$f"
+  done
+}
+render '{{ include "dragonfly.secrets.mysqlPasswordPlaceholder" . }}' "${DRAGONFLY_MYSQL_PASSWORD:-}"
+render '{{ include "dragonfly.secrets.redisPasswordPlaceholder" . }}' "${DRAGONFLY_REDIS_PASSWORD:-}"
+render '{{ include "dragonfly.secrets.redisSentinelPasswordPlaceholder" . }}' "${DRAGONFLY_REDIS_SENTINEL_PASSWORD:-}"
+render '{{ include "dragonfly.secrets.jwtKeyPlaceholder" . }}' "${DRAGONFLY_JWT_KEY:-}"
+{{- end -}}

--- a/charts/dragonfly/templates/manager/manager-configmap.yaml
+++ b/charts/dragonfly/templates/manager/manager-configmap.yaml
@@ -39,19 +39,35 @@ data:
       cacheDir: {{ .Values.manager.config.server.cacheDir }}
       pluginDir: {{ .Values.manager.config.server.pluginDir }}
     auth:
-{{ toYaml .Values.manager.config.auth | indent 6 }}
+      jwt:
+        realm: {{ .Values.manager.config.auth.jwt.realm }}
+        {{- if .Values.manager.config.auth.jwt.existingSecret }}
+        key: "{{ include "dragonfly.secrets.jwtKeyPlaceholder" . }}"
+        {{- else }}
+        key: {{ .Values.manager.config.auth.jwt.key }}
+        {{- end }}
+        timeout: {{ .Values.manager.config.auth.jwt.timeout }}
+        maxRefresh: {{ .Values.manager.config.auth.jwt.maxRefresh }}
     database:
       mysql:
         {{- if and .Values.mysql.enable (empty .Values.externalMysql.host)}}
         user: {{ .Values.mysql.auth.username }}
+        {{- if .Values.mysql.auth.existingSecret }}
+        password: "{{ include "dragonfly.secrets.mysqlPasswordPlaceholder" . }}"
+        {{- else }}
         password: {{ .Values.mysql.auth.password }}
+        {{- end }}
         host: {{ .Release.Name }}-{{ default "mysql" .Values.mysql.fullname }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
         port: {{ .Values.mysql.primary.service.port }}
         dbname: {{ .Values.mysql.auth.database }}
         migrate: {{ .Values.mysql.migrate }}
         {{- else }}
         user: {{ .Values.externalMysql.username }}
+        {{- if .Values.externalMysql.existingSecret }}
+        password: "{{ include "dragonfly.secrets.mysqlPasswordPlaceholder" . }}"
+        {{- else }}
         password: {{ .Values.externalMysql.password }}
+        {{- end }}
         host: {{ .Values.externalMysql.host }}
         port: {{ .Values.externalMysql.port }}
         dbname: {{ .Values.externalMysql.database }}
@@ -61,15 +77,27 @@ data:
         {{- if .Values.redis.enable }}
         addrs:
         - {{ .Release.Name }}-{{ default "redis" .Values.redis.fullname }}-master.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.redis.master.service.ports.redis }}
+        {{- if .Values.redis.auth.existingSecret }}
+        password: "{{ include "dragonfly.secrets.redisPasswordPlaceholder" . }}"
+        {{- else }}
         password: {{ .Values.redis.auth.password }}
+        {{- end }}
         {{- else }}
         addrs:
 {{ toYaml .Values.externalRedis.addrs | indent 10 }}
         masterName: {{ .Values.externalRedis.masterName }}
         username: {{ .Values.externalRedis.username }}
+        {{- if .Values.externalRedis.existingSecret }}
+        password: "{{ include "dragonfly.secrets.redisPasswordPlaceholder" . }}"
+        {{- else }}
         password: {{ .Values.externalRedis.password }}
+        {{- end }}
         sentinelUsername: {{ .Values.externalRedis.sentinelUsername }}
+        {{- if .Values.externalRedis.existingSecret }}
+        sentinelPassword: "{{ include "dragonfly.secrets.redisSentinelPasswordPlaceholder" . }}"
+        {{- else }}
         sentinelPassword: {{ .Values.externalRedis.sentinelPassword }}
+        {{- end }}
         db: {{ .Values.externalRedis.db }}
         brokerDB: {{ .Values.externalRedis.brokerDB }}
         backendDB: {{ .Values.externalRedis.backendDB }}

--- a/charts/dragonfly/templates/manager/manager-deployment.yaml
+++ b/charts/dragonfly/templates/manager/manager-deployment.yaml
@@ -66,7 +66,6 @@ spec:
       hostAliases:
 {{ toYaml .Values.manager.hostAliases | indent 8 }}
       {{- end }}
-      {{- if or .Values.redis.enable .Values.mysql.enable }}
       initContainers:
       {{- if .Values.redis.enable }}
       - name: wait-for-redis
@@ -84,7 +83,65 @@ spec:
         resources:
 {{ toYaml .Values.manager.initContainer.resources | indent 10 }}
       {{- end }}
-      {{- end }}
+      - name: render-secrets
+        image: {{ template "manager.image" . }}
+        imagePullPolicy: {{ .Values.manager.image.pullPolicy | quote }}
+        env:
+        {{- if and .Values.mysql.enable (empty .Values.externalMysql.host) }}
+        {{- if .Values.mysql.auth.existingSecret }}
+        - name: DRAGONFLY_MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.mysql.auth.existingSecret }}
+              key: mysql-password
+        {{- end }}
+        {{- else if .Values.externalMysql.existingSecret }}
+        - name: DRAGONFLY_MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.externalMysql.existingSecret }}
+              key: {{ .Values.externalMysql.existingSecretPasswordKey }}
+        {{- end }}
+        {{- if .Values.redis.enable }}
+        {{- if .Values.redis.auth.existingSecret }}
+        - name: DRAGONFLY_REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.redis.auth.existingSecret }}
+              key: {{ .Values.redis.auth.existingSecretPasswordKey | default "redis-password" }}
+        {{- end }}
+        {{- else if .Values.externalRedis.existingSecret }}
+        - name: DRAGONFLY_REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.externalRedis.existingSecret }}
+              key: {{ .Values.externalRedis.existingSecretPasswordKey }}
+        - name: DRAGONFLY_REDIS_SENTINEL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.externalRedis.existingSecret }}
+              key: {{ .Values.externalRedis.existingSecretSentinelPasswordKey }}
+        {{- end }}
+        {{- if .Values.manager.config.auth.jwt.existingSecret }}
+        - name: DRAGONFLY_JWT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.manager.config.auth.jwt.existingSecret }}
+              key: {{ .Values.manager.config.auth.jwt.existingSecretKeyKey }}
+        {{- end }}
+        command:
+        - sh
+        - -c
+        - |
+{{ include "dragonfly.renderSecretsScript" . | indent 10 }}
+        resources:
+{{ toYaml .Values.manager.initContainer.resources | indent 10 }}
+        volumeMounts:
+        - name: config-template
+          mountPath: /dragonfly-config-template
+          readOnly: true
+        - name: config
+          mountPath: /dragonfly-config
       containers:
       - name: manager
         image: {{ template "manager.image" . }}
@@ -141,12 +198,14 @@ spec:
           successThreshold: {{ .Values.livenessProbe.successThreshold }}
           failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
       volumes:
-      - name: config
+      - name: config-template
         configMap:
           name: {{ template "dragonfly.manager.fullname" . }}
           items:
           - key: manager.yaml
             path: manager.yaml
+      - name: config
+        emptyDir: {}
       {{- if .Values.manager.extraVolumes }}
       {{- toYaml .Values.manager.extraVolumes | nindent 6 }}
       {{- end }}

--- a/charts/dragonfly/templates/scheduler/scheduler-configmap.yaml
+++ b/charts/dragonfly/templates/scheduler/scheduler-configmap.yaml
@@ -20,15 +20,27 @@ data:
         {{- if .Values.redis.enable }}
         addrs:
         - {{ .Release.Name }}-{{ default "redis" .Values.redis.fullname }}-master.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.redis.master.service.ports.redis }}
+        {{- if .Values.redis.auth.existingSecret }}
+        password: "{{ include "dragonfly.secrets.redisPasswordPlaceholder" . }}"
+        {{- else }}
         password: {{ .Values.redis.auth.password }}
+        {{- end }}
         {{- else }}
         addrs:
 {{ toYaml .Values.externalRedis.addrs | indent 10 }}
         masterName: {{ .Values.externalRedis.masterName }}
         username: {{ .Values.externalRedis.username }}
+        {{- if .Values.externalRedis.existingSecret }}
+        password: "{{ include "dragonfly.secrets.redisPasswordPlaceholder" . }}"
+        {{- else }}
         password: {{ .Values.externalRedis.password }}
+        {{- end }}
         sentinelUsername: {{ .Values.externalRedis.sentinelUsername }}
+        {{- if .Values.externalRedis.existingSecret }}
+        sentinelPassword: "{{ include "dragonfly.secrets.redisSentinelPasswordPlaceholder" . }}"
+        {{- else }}
         sentinelPassword: {{ .Values.externalRedis.sentinelPassword }}
+        {{- end }}
         brokerDB: {{ .Values.externalRedis.brokerDB }}
         backendDB: {{ .Values.externalRedis.backendDB }}
         {{- with .Values.externalRedis.tls }}
@@ -65,15 +77,27 @@ data:
         {{- if .Values.redis.enable }}
         addrs:
         - {{ .Release.Name }}-{{ default "redis" .Values.redis.fullname }}-master.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.redis.master.service.ports.redis }}
+        {{- if .Values.redis.auth.existingSecret }}
+        password: "{{ include "dragonfly.secrets.redisPasswordPlaceholder" . }}"
+        {{- else }}
         password: {{ .Values.redis.auth.password }}
+        {{- end }}
         {{- else }}
         addrs:
 {{ toYaml .Values.externalRedis.addrs | indent 10 }}
         masterName: {{ .Values.externalRedis.masterName }}
         username: {{ .Values.externalRedis.username }}
+        {{- if .Values.externalRedis.existingSecret }}
+        password: "{{ include "dragonfly.secrets.redisPasswordPlaceholder" . }}"
+        {{- else }}
         password: {{ .Values.externalRedis.password }}
+        {{- end }}
         sentinelUsername: {{ .Values.externalRedis.sentinelUsername }}
+        {{- if .Values.externalRedis.existingSecret }}
+        sentinelPassword: "{{ include "dragonfly.secrets.redisSentinelPasswordPlaceholder" . }}"
+        {{- else }}
         sentinelPassword: {{ .Values.externalRedis.sentinelPassword }}
+        {{- end }}
         brokerDB: {{ .Values.externalRedis.brokerDB }}
         backendDB: {{ .Values.externalRedis.backendDB }}
         {{- with .Values.externalRedis.tls }}

--- a/charts/dragonfly/templates/scheduler/scheduler-statefulset.yaml
+++ b/charts/dragonfly/templates/scheduler/scheduler-statefulset.yaml
@@ -79,6 +79,43 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.scheduler.initContainer.resources | indent 10 }}
+      - name: render-secrets
+        image: {{ template "scheduler.image" . }}
+        imagePullPolicy: {{ .Values.scheduler.image.pullPolicy | quote }}
+        env:
+        {{- if .Values.redis.enable }}
+        {{- if .Values.redis.auth.existingSecret }}
+        - name: DRAGONFLY_REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.redis.auth.existingSecret }}
+              key: {{ .Values.redis.auth.existingSecretPasswordKey | default "redis-password" }}
+        {{- end }}
+        {{- else if .Values.externalRedis.existingSecret }}
+        - name: DRAGONFLY_REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.externalRedis.existingSecret }}
+              key: {{ .Values.externalRedis.existingSecretPasswordKey }}
+        - name: DRAGONFLY_REDIS_SENTINEL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.externalRedis.existingSecret }}
+              key: {{ .Values.externalRedis.existingSecretSentinelPasswordKey }}
+        {{- end }}
+        command:
+        - sh
+        - -c
+        - |
+{{ include "dragonfly.renderSecretsScript" . | indent 10 }}
+        resources:
+{{ toYaml .Values.scheduler.initContainer.resources | indent 10 }}
+        volumeMounts:
+        - name: config-template
+          mountPath: /dragonfly-config-template
+          readOnly: true
+        - name: config
+          mountPath: /dragonfly-config
       containers:
       - name: scheduler
         image: {{ template "scheduler.image" . }}
@@ -133,12 +170,14 @@ spec:
           successThreshold: {{ .Values.livenessProbe.successThreshold }}
           failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
       volumes:
-      - name: config
+      - name: config-template
         configMap:
           name: {{ template "dragonfly.scheduler.fullname" . }}
           items:
           - key: scheduler.yaml
             path: scheduler.yaml
+      - name: config
+        emptyDir: {}
       {{- if .Values.scheduler.extraVolumes }}
       {{- toYaml .Values.scheduler.extraVolumes | nindent 6 }}
       {{- end }}

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -220,7 +220,14 @@ manager:
         # -- Key is secret key used for signing, default value is
         # encoded base64 of dragonfly.
         # Please change the key in production.
+        # Ignored when existingSecret is set.
         key: 'ZHJhZ29uZmx5Cg=='
+        # -- existingSecret is the name of an existing secret containing the jwt signing key.
+        # The secret must contain the key defined by existingSecretKeyKey.
+        # When set, it takes precedence over the key field above.
+        existingSecret: ''
+        # -- existingSecretKeyKey is the key within existingSecret that holds the jwt signing key.
+        existingSecretKeyKey: 'jwt-key'
         # -- Timeout is duration that a jwt token is valid,
         # default duration is two days.
         timeout: 48h
@@ -1911,6 +1918,11 @@ externalManager:
   # -- External GRPC service port.
   grpcPort: 65003
 
+# mysql is a bitnami/mysql subchart. Its own auth.existingSecret field (with the fixed
+# mysql-root-password/mysql-password keys documented at
+# https://github.com/bitnami/charts/tree/main/bitnami/mysql#credentials) is honored both by the
+# mysql pod itself and by the manager, so rootPassword/password below can be left unset and
+# never need to be committed to git.
 mysql:
   # -- Enable mysql with docker container.
   enable: true
@@ -1923,12 +1935,17 @@ mysql:
   auth:
     # -- Mysql hostname.
     host: ''
-    # -- Mysql root password.
+    # -- Mysql root password. Ignored when existingSecret is set.
     rootPassword: dragonfly-root
     # -- Mysql username.
     username: dragonfly
-    # -- Mysql password.
+    # -- Mysql password. Ignored when existingSecret is set.
     password: dragonfly
+    # -- existingSecret is the name of an existing secret containing the mysql root and user
+    # passwords, under the fixed keys `mysql-root-password` and `mysql-password`. When set, it
+    # takes precedence over rootPassword/password above, both for the mysql pod and for the
+    # manager's own database connection.
+    existingSecret: ''
     # -- Mysql database name.
     database: manager
   primary:
@@ -1943,13 +1960,23 @@ externalMysql:
   host:
   # -- External mysql username.
   username: dragonfly
-  # -- External mysql password.
+  # -- External mysql password. Ignored when existingSecret is set.
   password: dragonfly
+  # -- existingSecret is the name of an existing secret containing the external mysql password.
+  # The secret must contain the key defined by existingSecretPasswordKey.
+  # When set, it takes precedence over the password field above.
+  existingSecret: ''
+  # -- existingSecretPasswordKey is the key within existingSecret that holds the external mysql password.
+  existingSecretPasswordKey: 'password'
   # -- External mysql database name.
   database: manager
   # -- External mysql port.
   port: 3306
 
+# redis is a bitnami/redis subchart. Its own auth.existingSecret/auth.existingSecretPasswordKey
+# fields (see https://github.com/bitnami/charts/tree/main/bitnami/redis#credentials) are honored
+# both by the redis pod itself and by the manager/scheduler, so password below can be left unset
+# and never need to be committed to git.
 redis:
   # -- Enable redis cluster with docker container.
   enable: true
@@ -1960,8 +1987,14 @@ redis:
   auth:
     # -- Enable password authentication.
     enabled: true
-    # -- Redis password.
+    # -- Redis password. Ignored when existingSecret is set.
     password: dragonfly
+    # -- existingSecret is the name of an existing secret containing the redis password. When
+    # set, it takes precedence over password above, both for the redis pod and for the
+    # manager/scheduler database connections.
+    existingSecret: ''
+    # -- existingSecretPasswordKey is the key within existingSecret that holds the redis password.
+    existingSecretPasswordKey: 'redis-password'
   master:
     service:
       ports:
@@ -1976,12 +2009,20 @@ externalRedis:
   masterName: ''
   # -- External redis username.
   username: ''
-  # -- External redis password.
+  # -- External redis password. Ignored when existingSecret is set.
   password: ''
+  # -- existingSecret is the name of an existing secret containing the external redis password
+  # and/or sentinel password.
+  existingSecret: ''
+  # -- existingSecretPasswordKey is the key within existingSecret that holds the external redis password.
+  existingSecretPasswordKey: 'password'
   # -- External redis sentinel addresses.
   sentinelUsername: ''
-  # -- External redis sentinel password.
+  # -- External redis sentinel password. Ignored when existingSecret is set.
   sentinelPassword: ''
+  # -- existingSecretSentinelPasswordKey is the key within existingSecret that holds the
+  # external redis sentinel password.
+  existingSecretSentinelPasswordKey: 'sentinel-password'
   # -- External redis db.
   db: 0
   # -- External redis broker db.


### PR DESCRIPTION
## Description

Today the manager/scheduler always need a **plaintext** mysql password, redis
password, and jwt signing key in `values.yaml` — there's no way to point at
an existing Kubernetes `Secret` instead, so any GitOps workflow ends up
committing these credentials to git.

Digging in, the gap isn't just "no `existingSecret` field": `mysql`/`redis`
are bitnami subcharts and already accept `auth.existingSecret` today — but
`manager`/`scheduler`'s own `ConfigMap`s (`manager.yaml` / `scheduler.yaml`)
still read `.Values.mysql.auth.password`, `.Values.redis.auth.password`,
`.Values.externalMysql.password`, `.Values.externalRedis.password`,
`.Values.externalRedis.sentinelPassword` and
`.Values.manager.config.auth.jwt.key` directly and inline them into a plain
`ConfigMap` (not even a `Secret`) to build their own database/auth config.
So even a user who *does* set `mysql.auth.existingSecret` still has to
duplicate the same password into `mysql.auth.password` for the manager to
pick up — which defeats the purpose.

This PR:
- Adds `existingSecret` (+ key) fields for `externalMysql`, `externalRedis`
  (password and sentinel password), and `manager.config.auth.jwt.key`.
  `mysql.auth.existingSecret` / `redis.auth.existingSecret` +
  `existingSecretPasswordKey` already exist via the bitnami subcharts and are
  now honored end-to-end too.
- Since the manager/scheduler binaries load their config file directly via
  viper with no environment-variable override support for nested keys
  (confirmed by reading `cmd/dependency/dependency.go` in
  [dragonflyoss/dragonfly](https://github.com/dragonflyoss/dragonfly)), a
  config-file-only fix isn't possible without changing the application. So
  when an `existingSecret` is configured, the affected `ConfigMap` field
  renders a placeholder token (e.g. `"__DRAGONFLY_MYSQL_PASSWORD__"`) instead
  of the real value, and a new `render-secrets` initContainer (reusing the
  manager/scheduler image itself, since it's alpine-based and already has
  `sh`/`sed`) resolves the placeholder from an env var sourced via
  `secretKeyRef`, writing the final config to an `emptyDir` that the main
  container mounts instead of the `ConfigMap` directly. The real secret value
  never touches Helm's render step or git.
- Substitution is careful about YAML/sed escaping so secrets containing
  `:`, `#`, `"`, `\`, `/` or `&` round-trip correctly (verified with a
  scripted byte-exact round-trip test through a real YAML parser).
- Default (plaintext) behavior is unchanged when `existingSecret` isn't set —
  the placeholder is never emitted and the substitution is a no-op.

## Related Issue

I couldn't find an existing tracked issue for this — opening as a draft in
case maintainers want this scoped differently, or want it split into a
tracked feature request first. Happy to open one if that's preferred.

## Motivation and Context

Storing database/JWT credentials in plaintext `values.yaml` is a common
blocker for GitOps deployments (Argo CD, Flux, etc.), where all values are
expected to live in git. This lets operators reference an existing `Secret`
(created out-of-band, e.g. via Sealed Secrets / External Secrets / Vault)
instead.

## Testing done

- `helm lint` and `helm template` against: default values, `existingSecret`
  set for mysql/redis/jwt, and `externalMysql`/`externalRedis` with
  `existingSecret` + sentinel password.
- `kubectl apply --dry-run=client` against all three renders to confirm the
  resulting manifests are schema-valid.
- Extracted a real rendered `manager.yaml` and ran the actual
  `render-secrets` script (with GNU sed, matching the container's `sed`)
  against secrets containing `: `, `#`, `"`, `\`, `/`, `&`, then parsed the
  result with a real YAML library and confirmed a byte-exact match against
  the original secret values.
- Regenerated `README.md` via `helm-docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
