### PR TITLE
feat: support running without the manager

### DIFF
--- a/charts/dragonfly/.helmignore
+++ b/charts/dragonfly/.helmignore
@@ -23,3 +23,5 @@
 .vscode/
 # Helm Docs
 README.md.gotmpl
+# Chart-testing values
+ci/

--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,8 +3,8 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.7.4
-appVersion: 2.5.0
+version: 1.7.5
+appVersion: 2.5.1
 keywords:
   - dragonfly
   - d7y
@@ -27,7 +27,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Change buffer size to 512KiB.
+    - Support running without the manager: deliver the local dynamic configuration (dynconfig.yaml) for the scheduler and client as ConfigMaps, add a scheduler headless service for DNS-based scheduler discovery, and disable the manager deployment by default.
   artifacthub.io/links: |
     - name: Chart Source
       url: https://github.com/dragonflyoss/helm-charts
@@ -37,15 +37,15 @@ annotations:
       url: https://github.com/dragonflyoss/client
   artifacthub.io/images: |
     - name: manager
-      image: dragonflyoss/manager:2.5.0
+      image: dragonflyoss/manager:2.5.1
     - name: scheduler
-      image: dragonflyoss/scheduler:v2.5.0
+      image: dragonflyoss/scheduler:v2.5.1
     - name: client
-      image: dragonflyoss/client:v1.4.0
+      image: dragonflyoss/client:v1.4.3
     - name: seed-client
-      image: dragonflyoss/client:v1.4.0
+      image: dragonflyoss/client:v1.4.3
     - name: dfinit
-      image: dragonflyoss/dfinit:v1.4.0
+      image: dragonflyoss/dfinit:v1.4.3
     - name: injector
       image: dragonflyoss/injector:v0.1.0
 

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -204,7 +204,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.dfinit.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | client.dfinit.image.registry | string | `"docker.io"` | Image registry. |
 | client.dfinit.image.repository | string | `"dragonflyoss/dfinit"` | Image repository. |
-| client.dfinit.image.tag | string | `"v1.4.0"` | Image tag. |
+| client.dfinit.image.tag | string | `"v1.4.3"` | Image tag. |
 | client.dfinit.restartContainerRuntime | bool | `true` | restartContainerRuntime indicates whether to restart container runtime when dfinit is enabled. it should be set to true when your first install dragonfly. If non-hot load configuration changes are made, the container runtime needs to be restarted. |
 | client.dynconfig | object | `{"clientConfig":{},"scheduler":{"addr":"","addrs":[]},"seedClientConfig":{}}` | dynconfig is the local dynamic configuration (dynconfig.yaml) for the client, delivered as a ConfigMap and mounted into the same directory as dfdaemon.yaml. It is only used when no manager is available (manager.enable is false and externalManager.host is empty), and it is refreshed periodically according to client.config.dynconfig.refreshInterval. |
 | client.dynconfig.clientConfig | object | `{}` | clientConfig is the block list configuration for clients running as normal peers, e.g. clientConfig: { blockList: { task: { download: { applications: [], urls: [], tags: [], priorities: [] } } } }. |
@@ -225,7 +225,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | client.image.registry | string | `"docker.io"` | Image registry. |
 | client.image.repository | string | `"dragonflyoss/client"` | Image repository. |
-| client.image.tag | string | `"v1.4.0"` | Image tag. |
+| client.image.tag | string | `"v1.4.3"` | Image tag. |
 | client.initContainer.image.digest | string | `""` | Image digest. |
 | client.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | client.initContainer.image.registry | string | `"docker.io"` | Image registry. |
@@ -303,13 +303,13 @@ helm delete dragonfly --namespace dragonfly-system
 | injector.image.registry | string | `"docker.io"` | Image registry. |
 | injector.image.repository | string | `"dragonflyoss/injector"` | Image repository. |
 | injector.image.tag | string | `"v0.1.0"` | Image tag. |
-| injector.initContainerImage | object | `{"digest":"","pullPolicy":"IfNotPresent","pullSecrets":[],"registry":"docker.io","repository":"dragonflyoss/client","tag":"v1.4.0"}` | initContainerImage is the image configuration for the init container that will be injected into target pods. |
+| injector.initContainerImage | object | `{"digest":"","pullPolicy":"IfNotPresent","pullSecrets":[],"registry":"docker.io","repository":"dragonflyoss/client","tag":"v1.4.3"}` | initContainerImage is the image configuration for the init container that will be injected into target pods. |
 | injector.initContainerImage.digest | string | `""` | Image digest. |
 | injector.initContainerImage.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | injector.initContainerImage.pullSecrets | list | `[]` | Image pull secrets. |
 | injector.initContainerImage.registry | string | `"docker.io"` | Image registry. |
 | injector.initContainerImage.repository | string | `"dragonflyoss/client"` | Image repository. |
-| injector.initContainerImage.tag | string | `"v1.4.0"` | Image tag. Should align with the version of Dragonfly client and seed client. |
+| injector.initContainerImage.tag | string | `"v1.4.3"` | Image tag. Should align with the version of Dragonfly client and seed client. |
 | injector.metrics.enable | bool | `false` | Enable injector metrics. |
 | injector.metrics.service.port | int | `8443` | Metrics service port. |
 | injector.nodeSelector | object | `{}` | Node labels for pod assignment. |
@@ -375,7 +375,7 @@ helm delete dragonfly --namespace dragonfly-system
 | manager.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | manager.image.registry | string | `"docker.io"` | Image registry. |
 | manager.image.repository | string | `"dragonflyoss/manager"` | Image repository. |
-| manager.image.tag | string | `"v2.5.0"` | Image tag. |
+| manager.image.tag | string | `"v2.5.1"` | Image tag. |
 | manager.ingress.annotations | object | `{}` | Ingress annotations. |
 | manager.ingress.className | string | `""` | Ingress class name. Requirement: kubernetes >=1.18. |
 | manager.ingress.enable | bool | `false` | Enable ingress. |
@@ -497,7 +497,7 @@ helm delete dragonfly --namespace dragonfly-system
 | scheduler.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | scheduler.image.registry | string | `"docker.io"` | Image registry. |
 | scheduler.image.repository | string | `"dragonflyoss/scheduler"` | Image repository. |
-| scheduler.image.tag | string | `"v2.5.0"` | Image tag. |
+| scheduler.image.tag | string | `"v2.5.1"` | Image tag. |
 | scheduler.initContainer.image.digest | string | `""` | Image digest. |
 | scheduler.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | scheduler.initContainer.image.registry | string | `"docker.io"` | Image registry. |
@@ -617,7 +617,7 @@ helm delete dragonfly --namespace dragonfly-system
 | seedClient.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | seedClient.image.registry | string | `"docker.io"` | Image registry. |
 | seedClient.image.repository | string | `"dragonflyoss/client"` | Image repository. |
-| seedClient.image.tag | string | `"v1.4.0"` | Image tag. |
+| seedClient.image.tag | string | `"v1.4.3"` | Image tag. |
 | seedClient.initContainer.image.digest | string | `""` | Image digest. |
 | seedClient.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | seedClient.initContainer.image.registry | string | `"docker.io"` | Image registry. |

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -156,7 +156,6 @@ helm delete dragonfly --namespace dragonfly-system
 | client.config.host.location | string | `""` | location is the location of the host. |
 | client.config.host.schedulerClusterID | int | `1` | schedulerClusterID is the ID of the cluster to which the scheduler belongs. NOTE: This field is used to identify the cluster to which the scheduler belongs. If this flag is set, the idc, location, hostname and ip will be ignored when listing schedulers. The system will automatically create a scheduler cluster with an ID of 1 by default. |
 | client.config.log.level | string | `"info"` | Specify the logging level [trace, debug, info, warn, error] |
-| client.config.manager.addr | string | `""` | addr is manager address. |
 | client.config.metrics.server.port | int | `4002` | port is the port to the metrics server. |
 | client.config.network.enableIPv6 | bool | `false` | enableIPv6 specifies whether to enable IPv6 networking. |
 | client.config.proxy.disableBackToSource | bool | `false` | disableBackToSource indicates whether disable to download back-to-source when download failed. |
@@ -207,6 +206,11 @@ helm delete dragonfly --namespace dragonfly-system
 | client.dfinit.image.repository | string | `"dragonflyoss/dfinit"` | Image repository. |
 | client.dfinit.image.tag | string | `"v1.4.0"` | Image tag. |
 | client.dfinit.restartContainerRuntime | bool | `true` | restartContainerRuntime indicates whether to restart container runtime when dfinit is enabled. it should be set to true when your first install dragonfly. If non-hot load configuration changes are made, the container runtime needs to be restarted. |
+| client.dynconfig | object | `{"clientConfig":{},"scheduler":{"addr":"","addrs":[]},"seedClientConfig":{}}` | dynconfig is the local dynamic configuration (dynconfig.yaml) for the client, delivered as a ConfigMap and mounted into the same directory as dfdaemon.yaml. It is only used when no manager is available (manager.enable is false and externalManager.host is empty), and it is refreshed periodically according to client.config.dynconfig.refreshInterval. |
+| client.dynconfig.clientConfig | object | `{}` | clientConfig is the block list configuration for clients running as normal peers, e.g. clientConfig: { blockList: { task: { download: { applications: [], urls: [], tags: [], priorities: [] } } } }. |
+| client.dynconfig.scheduler.addr | string | `""` | addr is the address of the scheduler headless service with port, resolved via DNS to discover all scheduler IPs. If empty, it defaults to the scheduler headless service address of this chart. |
+| client.dynconfig.scheduler.addrs | list | `[]` | addrs is the static list of scheduler addresses with port (e.g. ['192.168.1.10:8002']). When non-empty, it takes precedence over addr. |
+| client.dynconfig.seedClientConfig | object | `{}` | seedClientConfig is the block list configuration for clients running as seed peers. |
 | client.enable | bool | `true` | Enable client. |
 | client.extraEnvVars | list | `[]` | Extra environment variables for pod. |
 | client.extraVolumeMounts | list | `[{"mountPath":"/var/lib/dragonfly/","name":"storage"},{"mountPath":"/var/log/dragonfly/dfdaemon/","name":"logs"}]` | Extra volumeMounts for dfdaemon. |
@@ -254,7 +258,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.updateStrategy | object | `{"rollingUpdate":{"maxSurge":0,"maxUnavailable":20},"type":"RollingUpdate"}` | Update strategy for replicas. |
 | clusterDomain | string | `"cluster.local"` | Install application cluster domain. |
 | externalManager.grpcPort | int | `65003` | External GRPC service port. |
-| externalManager.host | string | `nil` | External manager hostname. |
+| externalManager.host | string | `""` | External manager hostname. |
 | externalManager.restPort | int | `8080` | External REST service port. |
 | externalMysql.database | string | `"manager"` | External mysql database name. |
 | externalMysql.host | string | `nil` | External mysql hostname. |
@@ -262,7 +266,7 @@ helm delete dragonfly --namespace dragonfly-system
 | externalMysql.password | string | `"dragonfly"` | External mysql password. |
 | externalMysql.port | int | `3306` | External mysql port. |
 | externalMysql.username | string | `"dragonfly"` | External mysql username. |
-| externalRedis.addrs | list | `["redis.example.com:6379"]` | External redis server addresses. |
+| externalRedis.addrs | list | `[]` | External redis server addresses (e.g. ['redis.example.com:6379']), required when the manager is deployed and redis.enable is false. If empty, the scheduler runs without redis and disables the redis-dependent features (e.g. job). |
 | externalRedis.backendDB | int | `2` | External redis backend db. |
 | externalRedis.brokerDB | int | `1` | External redis broker db. |
 | externalRedis.db | int | `0` | External redis db. |
@@ -358,7 +362,7 @@ helm delete dragonfly --namespace dragonfly-system
 | manager.config.server.workHome | string | `""` | Work directory. |
 | manager.config.tracing.protocol | string | `"grpc"` | Protocol specifies the communication protocol for the tracing server. Supported values: "http", "https", "grpc" (default: None). This determines how tracing logs are transmitted to the server. |
 | manager.deploymentAnnotations | object | `{}` | Deployment annotations. |
-| manager.enable | bool | `true` | Enable manager. |
+| manager.enable | bool | `false` | Enable manager. |
 | manager.extraEnvVars | list | `[]` | Extra environment variables for pod. |
 | manager.extraVolumeMounts | list | `[{"mountPath":"/var/log/dragonfly/manager","name":"logs"}]` | Extra volumeMounts for manager. |
 | manager.extraVolumes | list | `[{"emptyDir":{},"name":"logs"}]` | Extra volumes for manager. |
@@ -421,7 +425,7 @@ helm delete dragonfly --namespace dragonfly-system
 | mysql.auth.rootPassword | string | `"dragonfly-root"` | Mysql root password. |
 | mysql.auth.username | string | `"dragonfly"` | Mysql username. |
 | mysql.clusterDomain | string | `"cluster.local"` | Cluster domain. |
-| mysql.enable | bool | `true` | Enable mysql with docker container. |
+| mysql.enable | bool | `false` | Enable mysql with docker container, only used when the manager is deployed. |
 | mysql.image.repository | string | `"bitnamilegacy/mysql"` |  |
 | mysql.migrate | bool | `true` | Running GORM migration. |
 | mysql.primary.service.port | int | `3306` | Mysql port. |
@@ -436,7 +440,7 @@ helm delete dragonfly --namespace dragonfly-system
 | redis.auth.enabled | bool | `true` | Enable password authentication. |
 | redis.auth.password | string | `"dragonfly"` | Redis password. |
 | redis.clusterDomain | string | `"cluster.local"` | Cluster domain. |
-| redis.enable | bool | `true` | Enable redis cluster with docker container. |
+| redis.enable | bool | `false` | Enable redis cluster with docker container, only used when the manager is deployed. |
 | redis.image.repository | string | `"bitnamilegacy/redis"` |  |
 | redis.master.service.ports.redis | int | `6379` | Redis master service port. |
 | scheduler.config.console | bool | `true` | Console shows log on console. |
@@ -456,7 +460,7 @@ helm delete dragonfly --namespace dragonfly-system
 | scheduler.config.scheduler.gc.pieceDownloadTimeout | string | `"30m"` | pieceDownloadTimeout is the timeout of downloading piece. |
 | scheduler.config.scheduler.gc.taskGCInterval | string | `"30m"` | taskGCInterval is the interval of task gc. If all the peers have been reclaimed in the task, then the task will also be reclaimed. |
 | scheduler.config.scheduler.retryBackToSourceLimit | int | `3` | retryBackToSourceLimit reaches the limit, then the peer back-to-source. |
-| scheduler.config.scheduler.retryInterval | string | `"2s"` | Retry scheduling interval. |
+| scheduler.config.scheduler.retryInterval | string | `"1s"` | Retry scheduling interval. |
 | scheduler.config.scheduler.retryLimit | int | `5` | Retry scheduling limit times. |
 | scheduler.config.seedPeer | string | `nil` |  |
 | scheduler.config.server.advertiseIP | string | `""` | Advertise ip. |
@@ -472,6 +476,15 @@ helm delete dragonfly --namespace dragonfly-system
 | scheduler.config.server.workHome | string | `""` | Work directory. |
 | scheduler.config.tracing.protocol | string | `""` | Protocol specifies the communication protocol for the tracing server. Supported values: "http", "https", "grpc" (default: None). This determines how tracing logs are transmitted to the server. |
 | scheduler.containerPort | int | `8002` | Pod containerPort. |
+| scheduler.dynconfig | object | `{"applications":[],"schedulerClusterClientConfig":{"loadLimit":200},"schedulerClusterConfig":{"candidateParentLimit":3,"filterParentLimit":15},"seedPeerClusterConfig":{"loadLimit":2000}}` | dynconfig is the local dynamic configuration (dynconfig.yaml) for the scheduler, delivered as a ConfigMap and mounted into the same directory as scheduler.yaml. It is only used when no manager is available (manager.enable is false and externalManager.host is empty), and it is refreshed periodically according to scheduler.config.dynconfig.refreshInterval. |
+| scheduler.dynconfig.applications | list | `[]` | applications is the applications configuration. |
+| scheduler.dynconfig.schedulerClusterClientConfig | object | `{"loadLimit":200}` | schedulerClusterClientConfig is the client configuration. |
+| scheduler.dynconfig.schedulerClusterClientConfig.loadLimit | int | `200` | loadLimit is the peer concurrent upload limit. |
+| scheduler.dynconfig.schedulerClusterConfig | object | `{"candidateParentLimit":3,"filterParentLimit":15}` | schedulerClusterConfig is the scheduler cluster configuration. |
+| scheduler.dynconfig.schedulerClusterConfig.candidateParentLimit | int | `3` | candidateParentLimit is the candidate parent limit for scheduling. |
+| scheduler.dynconfig.schedulerClusterConfig.filterParentLimit | int | `15` | filterParentLimit is the filter parent limit for scheduling. |
+| scheduler.dynconfig.seedPeerClusterConfig | object | `{"loadLimit":2000}` | seedPeerClusterConfig is the seed peer cluster configuration. |
+| scheduler.dynconfig.seedPeerClusterConfig.loadLimit | int | `2000` | loadLimit is the seed peer concurrent upload limit. |
 | scheduler.enable | bool | `true` | Enable scheduler. |
 | scheduler.extraEnvVars | list | `[]` | Extra environment variables for pod. |
 | scheduler.extraVolumeMounts | list | `[{"mountPath":"/var/log/dragonfly/scheduler","name":"logs"}]` | Extra volumeMounts for scheduler. |
@@ -513,11 +526,9 @@ helm delete dragonfly --namespace dragonfly-system
 | scheduler.priorityClassName | string | `""` | Pod priorityClassName. |
 | scheduler.replicas | int | `3` | Number of Pods to launch. |
 | scheduler.resources | object | `{"limits":{"cpu":"8","memory":"16Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits. |
+| scheduler.service | object | `{"annotations":{},"labels":{}}` | Scheduler service configuration. The scheduler service is headless, so that clients can discover all scheduler IPs via DNS. |
 | scheduler.service.annotations | object | `{}` | Service annotations. |
-| scheduler.service.clusterIP | string | `""` | Service clusterIP. |
 | scheduler.service.labels | object | `{}` | Service labels. |
-| scheduler.service.nodePort | string | `""` | Service nodePort. |
-| scheduler.service.type | string | `"ClusterIP"` | Service type. |
 | scheduler.statefulsetAnnotations | object | `{}` | Statefulset annotations. |
 | scheduler.terminationGracePeriodSeconds | string | `nil` | Pod terminationGracePeriodSeconds. |
 | scheduler.tolerations | list | `[]` | List of node taints to tolerate. |
@@ -552,7 +563,6 @@ helm delete dragonfly --namespace dragonfly-system
 | seedClient.config.host.location | string | `""` | location is the location of the host. |
 | seedClient.config.host.schedulerClusterID | int | `1` | schedulerClusterID is the ID of the cluster to which the scheduler belongs. NOTE: This field is used to identify the cluster to which the scheduler belongs. If this flag is set, the idc, location, hostname and ip will be ignored when listing schedulers. The system will automatically create a scheduler cluster with an ID of 1 by default. |
 | seedClient.config.log.level | string | `"info"` | Specify the logging level [trace, debug, info, warn, error] |
-| seedClient.config.manager.addr | string | `""` | addr is manager address. |
 | seedClient.config.metrics.server.port | int | `4002` | port is the port to the metrics server. |
 | seedClient.config.network.enableIPv6 | bool | `false` | enableIPv6 specifies whether to enable IPv6 networking. |
 | seedClient.config.proxy.disableBackToSource | bool | `false` | disableBackToSource indicates whether disable to download back-to-source when download failed. |
@@ -590,6 +600,11 @@ helm delete dragonfly --namespace dragonfly-system
 | seedClient.config.upload.server.port | int | `4000` | port is the port to the grpc server. |
 | seedClient.config.upload.server.requestRateLimit | int | `400` | requestRateLimit is the rate limit of the upload server's request in dfdaemon, default is 400 req/s.  This limit applies to the total number of gRPC requests per second, including: - Multiple requests within a single connection. - Single requests across different connections. |
 | seedClient.config.upload.server.requestbufferSize | int | `50` | requestbufferSize is the buffer size of the upload server's request channel in dfdaemon, default is 50.  This controls the capacity of the bounded channel used to queue incoming gRPC requests before they are processed. If the buffer is full, new requests will return a `RESOURCE_EXHAUSTED` error. |
+| seedClient.dynconfig | object | `{"clientConfig":{},"scheduler":{"addr":"","addrs":[]},"seedClientConfig":{}}` | dynconfig is the local dynamic configuration (dynconfig.yaml) for the seed client, delivered as a ConfigMap and mounted into the same directory as dfdaemon.yaml. It is only used when no manager is available (manager.enable is false and externalManager.host is empty), and it is refreshed periodically according to seedClient.config.dynconfig.refreshInterval. |
+| seedClient.dynconfig.clientConfig | object | `{}` | clientConfig is the block list configuration for clients running as normal peers, e.g. clientConfig: { blockList: { task: { download: { applications: [], urls: [], tags: [], priorities: [] } } } }. |
+| seedClient.dynconfig.scheduler.addr | string | `""` | addr is the address of the scheduler headless service with port, resolved via DNS to discover all scheduler IPs. If empty, it defaults to the scheduler headless service address of this chart. |
+| seedClient.dynconfig.scheduler.addrs | list | `[]` | addrs is the static list of scheduler addresses with port (e.g. ['192.168.1.10:8002']). When non-empty, it takes precedence over addr. |
+| seedClient.dynconfig.seedClientConfig | object | `{}` | seedClientConfig is the block list configuration for clients running as seed peers. |
 | seedClient.enable | bool | `true` | Enable seed client. |
 | seedClient.extraEnvVars | list | `[]` | Extra environment variables for pod. |
 | seedClient.extraVolumeMounts | list | `[{"mountPath":"/var/log/dragonfly/dfdaemon/","name":"logs"}]` | Extra volumeMounts for dfdaemon. |

--- a/charts/dragonfly/ci/default-values.yaml
+++ b/charts/dragonfly/ci/default-values.yaml
@@ -1,0 +1,4 @@
+# Chart-testing (ct lint/install) values: install with the default values, which run
+# Dragonfly without the manager, and the scheduler and client load the dynamic
+# configuration from the local dynconfig.yaml file mounted as a ConfigMap.
+{}

--- a/charts/dragonfly/ci/manager-values.yaml
+++ b/charts/dragonfly/ci/manager-values.yaml
@@ -1,0 +1,8 @@
+# Chart-testing (ct lint/install) values: install with the manager stack enabled,
+# including the mysql and redis dependencies required by the manager.
+manager:
+  enable: true
+mysql:
+  enable: true
+redis:
+  enable: true

--- a/charts/dragonfly/templates/NOTES.txt
+++ b/charts/dragonfly/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{- if .Values.manager.enable }}
 1. Get the manager address by running these commands:
   export MANAGER_POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ include "dragonfly.fullname" . }},release={{ .Release.Name }},component=manager" -o jsonpath={.items[0].metadata.name})
   export MANAGER_CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $MANAGER_POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
@@ -12,3 +13,27 @@
 
 3. Configure runtime to use dragonfly:
   https://d7y.io/docs/getting-started/quick-start/kubernetes/
+{{- else if .Values.externalManager.host }}
+1. Get the scheduler address by running these commands:
+  export SCHEDULER_POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ include "dragonfly.fullname" . }},release={{ .Release.Name }},component=scheduler" -o jsonpath={.items[0].metadata.name})
+  export SCHEDULER_CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $SCHEDULER_POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  kubectl --namespace {{ .Release.Namespace }} port-forward $SCHEDULER_POD_NAME 8002:$SCHEDULER_CONTAINER_PORT
+  echo "Visit http://127.0.0.1:8002 to use your scheduler"
+
+2. Configure runtime to use dragonfly:
+  https://d7y.io/docs/getting-started/quick-start/kubernetes/
+{{- else }}
+1. Dragonfly is running without the manager. The scheduler and client load the dynamic
+   configuration from the local dynconfig.yaml file mounted as a ConfigMap, and clients
+   discover schedulers via the scheduler headless service:
+  {{ template "dragonfly.scheduler.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.scheduler.config.server.port }}
+
+2. Get the scheduler address by running these commands:
+  export SCHEDULER_POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ include "dragonfly.fullname" . }},release={{ .Release.Name }},component=scheduler" -o jsonpath={.items[0].metadata.name})
+  export SCHEDULER_CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $SCHEDULER_POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  kubectl --namespace {{ .Release.Namespace }} port-forward $SCHEDULER_POD_NAME 8002:$SCHEDULER_CONTAINER_PORT
+  echo "Visit http://127.0.0.1:8002 to use your scheduler"
+
+3. Configure runtime to use dragonfly:
+  https://d7y.io/docs/getting-started/quick-start/kubernetes/
+{{- end }}

--- a/charts/dragonfly/templates/_helpers.tpl
+++ b/charts/dragonfly/templates/_helpers.tpl
@@ -47,6 +47,18 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Return "true" if a manager is available, either deployed by this chart (manager.enable)
+or provided externally (externalManager.host). If neither is configured, the scheduler
+and client load the dynamic configuration from the local dynconfig.yaml file mounted as
+a ConfigMap instead of fetching it from the manager.
+*/}}
+{{- define "dragonfly.manager.enable" -}}
+{{- if or .Values.manager.enable .Values.externalManager.host -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified client name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/charts/dragonfly/templates/client/client-configmap.yaml
+++ b/charts/dragonfly/templates/client/client-configmap.yaml
@@ -19,14 +19,13 @@ data:
 {{ toYaml .Values.client.config.download | indent 6 }}
     upload:
 {{ toYaml .Values.client.config.upload | indent 6 }}
+    {{- if .Values.manager.enable }}
     manager:
-      {{- if .Values.client.config.manager.addr }}
-      addr: {{ .Values.client.config.manager.addr }}
-      {{- else if .Values.manager.enable }}
       addr: http://{{ template "dragonfly.manager.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.manager.grpcPort }}
-      {{- else }}
+    {{- else if .Values.externalManager.host }}
+    manager:
       addr: http://{{ .Values.externalManager.host }}:{{ .Values.externalManager.grpcPort }}
-      {{- end }}
+    {{- end }}
     scheduler:
 {{ toYaml .Values.client.config.scheduler | indent 6 }}
     dynconfig:
@@ -49,4 +48,25 @@ data:
 {{ toYaml .Values.client.config.backend | indent 6 }}
     network:
 {{ toYaml .Values.client.config.network | indent 6 }}
+  {{- if not (include "dragonfly.manager.enable" .) }}
+  dynconfig.yaml: |-
+    scheduler:
+      {{- if .Values.client.dynconfig.scheduler.addr }}
+      addr: {{ .Values.client.dynconfig.scheduler.addr }}
+      {{- else }}
+      addr: {{ template "dragonfly.scheduler.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.scheduler.config.server.port }}
+      {{- end }}
+      {{- if .Values.client.dynconfig.scheduler.addrs }}
+      addrs:
+{{ toYaml .Values.client.dynconfig.scheduler.addrs | indent 6 }}
+      {{- end }}
+    {{- if .Values.client.dynconfig.clientConfig }}
+    clientConfig:
+{{ toYaml .Values.client.dynconfig.clientConfig | indent 6 }}
+    {{- end }}
+    {{- if .Values.client.dynconfig.seedClientConfig }}
+    seedClientConfig:
+{{ toYaml .Values.client.dynconfig.seedClientConfig | indent 6 }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/dragonfly/templates/manager/manager-configmap.yaml
+++ b/charts/dragonfly/templates/manager/manager-configmap.yaml
@@ -62,7 +62,7 @@ data:
         addrs:
         - {{ .Release.Name }}-{{ default "redis" .Values.redis.fullname }}-master.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.redis.master.service.ports.redis }}
         password: {{ .Values.redis.auth.password }}
-        {{- else }}
+        {{- else if .Values.externalRedis.addrs }}
         addrs:
 {{ toYaml .Values.externalRedis.addrs | indent 10 }}
         masterName: {{ .Values.externalRedis.masterName }}

--- a/charts/dragonfly/templates/manager/manager-ingress.yaml
+++ b/charts/dragonfly/templates/manager/manager-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.manager.ingress.enable -}}
+{{- if and .Values.manager.enable .Values.manager.ingress.enable -}}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
 {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}

--- a/charts/dragonfly/templates/manager/metrics-svc.yaml
+++ b/charts/dragonfly/templates/manager/metrics-svc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.manager.metrics.enable }}
+{{- if and .Values.manager.enable .Values.manager.metrics.enable }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/dragonfly/templates/manager/prometheusrule.yaml
+++ b/charts/dragonfly/templates/manager/prometheusrule.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.manager.metrics.enable .Values.manager.metrics.prometheusRule.enable }}
+{{- if and .Values.manager.enable .Values.manager.metrics.enable .Values.manager.metrics.prometheusRule.enable }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/charts/dragonfly/templates/manager/servicemonitor.yaml
+++ b/charts/dragonfly/templates/manager/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.manager.metrics.enable .Values.manager.metrics.serviceMonitor.enable }}
+{{- if and .Values.manager.enable .Values.manager.metrics.enable .Values.manager.metrics.serviceMonitor.enable }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/dragonfly/templates/scheduler/scheduler-configmap.yaml
+++ b/charts/dragonfly/templates/scheduler/scheduler-configmap.yaml
@@ -21,7 +21,7 @@ data:
         addrs:
         - {{ .Release.Name }}-{{ default "redis" .Values.redis.fullname }}-master.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.redis.master.service.ports.redis }}
         password: {{ .Values.redis.auth.password }}
-        {{- else }}
+        {{- else if .Values.externalRedis.addrs }}
         addrs:
 {{ toYaml .Values.externalRedis.addrs | indent 10 }}
         masterName: {{ .Values.externalRedis.masterName }}
@@ -52,7 +52,7 @@ data:
     manager:
       {{- if .Values.manager.enable }}
       addr: {{ template "dragonfly.manager.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.manager.grpcPort }}
-      {{- else }}
+      {{- else if .Values.externalManager.host }}
       addr: {{ .Values.externalManager.host }}:{{ .Values.externalManager.grpcPort }}
       {{- end }}
       schedulerClusterID: {{ .Values.scheduler.config.manager.schedulerClusterID }}
@@ -66,7 +66,7 @@ data:
         addrs:
         - {{ .Release.Name }}-{{ default "redis" .Values.redis.fullname }}-master.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.redis.master.service.ports.redis }}
         password: {{ .Values.redis.auth.password }}
-        {{- else }}
+        {{- else if .Values.externalRedis.addrs }}
         addrs:
 {{ toYaml .Values.externalRedis.addrs | indent 10 }}
         masterName: {{ .Values.externalRedis.masterName }}
@@ -102,4 +102,8 @@ data:
     pprofPort: {{ .Values.scheduler.config.pprofPort }}
     tracing:
 {{ toYaml .Values.scheduler.config.tracing | indent 6 }}
+  {{- if not (include "dragonfly.manager.enable" .) }}
+  dynconfig.yaml: |-
+{{ toYaml .Values.scheduler.dynconfig | indent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/dragonfly/templates/scheduler/scheduler-configmap.yaml
+++ b/charts/dragonfly/templates/scheduler/scheduler-configmap.yaml
@@ -15,6 +15,7 @@ data:
 {{ toYaml .Values.scheduler.config.server | indent 6 }}
     scheduler:
 {{ toYaml .Values.scheduler.config.scheduler | indent 6 }}
+    {{- if or .Values.redis.enable .Values.externalRedis.addrs }}
     database:
       redis:
         {{- if .Values.redis.enable }}
@@ -45,6 +46,7 @@ data:
         {{- end }}
         {{- end }}
         {{- end }}
+    {{- end }}
     dynconfig:
 {{ toYaml .Values.scheduler.config.dynconfig | indent 6 }}
     host:
@@ -60,6 +62,7 @@ data:
 {{ toYaml .Values.scheduler.config.manager.keepAlive | indent 8 }}
     seedPeer:
 {{ toYaml .Values.scheduler.config.seedPeer | indent 6 }}
+    {{- if or .Values.redis.enable .Values.externalRedis.addrs }}
     job:
       redis:
         {{- if .Values.redis.enable }}
@@ -90,6 +93,7 @@ data:
         {{- end }}
         {{- end }}
         {{- end }}
+    {{- end }}
     storage:
 {{ toYaml .Values.scheduler.config.storage | indent 6 }}
     network:

--- a/charts/dragonfly/templates/scheduler/scheduler-statefulset.yaml
+++ b/charts/dragonfly/templates/scheduler/scheduler-statefulset.yaml
@@ -68,6 +68,7 @@ spec:
       hostAliases:
 {{ toYaml .Values.scheduler.hostAliases | indent 8 }}
       {{- end }}
+      {{- if include "dragonfly.manager.enable" . }}
       initContainers:
       - name: wait-for-manager
         image: {{ template "scheduler.initContainer.image" . }}
@@ -79,6 +80,7 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.scheduler.initContainer.resources | indent 10 }}
+      {{- end }}
       containers:
       - name: scheduler
         image: {{ template "scheduler.image" . }}
@@ -139,6 +141,10 @@ spec:
           items:
           - key: scheduler.yaml
             path: scheduler.yaml
+          {{- if not (include "dragonfly.manager.enable" .) }}
+          - key: dynconfig.yaml
+            path: dynconfig.yaml
+          {{- end }}
       {{- if .Values.scheduler.extraVolumes }}
       {{- toYaml .Values.scheduler.extraVolumes | nindent 6 }}
       {{- end }}

--- a/charts/dragonfly/templates/scheduler/scheduler-svc.yaml
+++ b/charts/dragonfly/templates/scheduler/scheduler-svc.yaml
@@ -17,8 +17,8 @@ metadata:
 {{ toYaml .Values.scheduler.service.annotations | indent 4 }}
 {{- end }}
 spec:
-  type: {{ .Values.scheduler.service.type }}
-  clusterIP: {{ .Values.scheduler.service.clusterIP }}
+  type: ClusterIP
+  clusterIP: None
   ports:
     - port: {{ .Values.scheduler.config.server.port }}
       name: grpc
@@ -27,9 +27,6 @@ spec:
       {{- end }}
       protocol: TCP
       targetPort: {{ .Values.scheduler.config.server.port }}
-{{- if eq .Values.scheduler.service.type "NodePort" }}
-      nodePort: {{ .Values.scheduler.service.nodePort }}
-{{- end }}
   selector:
     app: {{ template "dragonfly.fullname" . }}
     component: {{ .Values.scheduler.name }}

--- a/charts/dragonfly/templates/seed-client/seed-client-configmap.yaml
+++ b/charts/dragonfly/templates/seed-client/seed-client-configmap.yaml
@@ -19,14 +19,13 @@ data:
 {{ toYaml .Values.seedClient.config.download | indent 6 }}
     upload:
 {{ toYaml .Values.seedClient.config.upload | indent 6 }}
+    {{- if .Values.manager.enable }}
     manager:
-      {{- if .Values.seedClient.config.manager.addr }}
-      addr: {{ .Values.seedClient.config.manager.addr }}
-      {{- else if .Values.manager.enable }}
       addr: http://{{ template "dragonfly.manager.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.manager.grpcPort }}
-      {{- else }}
+    {{- else if .Values.externalManager.host }}
+    manager:
       addr: http://{{ .Values.externalManager.host }}:{{ .Values.externalManager.grpcPort }}
-      {{- end }}
+    {{- end }}
     scheduler:
 {{ toYaml .Values.seedClient.config.scheduler | indent 6 }}
     seedPeer:
@@ -51,4 +50,25 @@ data:
 {{ toYaml .Values.seedClient.config.backend | indent 6 }}
     network:
 {{ toYaml .Values.seedClient.config.network | indent 6 }}
+  {{- if not (include "dragonfly.manager.enable" .) }}
+  dynconfig.yaml: |-
+    scheduler:
+      {{- if .Values.seedClient.dynconfig.scheduler.addr }}
+      addr: {{ .Values.seedClient.dynconfig.scheduler.addr }}
+      {{- else }}
+      addr: {{ template "dragonfly.scheduler.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.scheduler.config.server.port }}
+      {{- end }}
+      {{- if .Values.seedClient.dynconfig.scheduler.addrs }}
+      addrs:
+{{ toYaml .Values.seedClient.dynconfig.scheduler.addrs | indent 6 }}
+      {{- end }}
+    {{- if .Values.seedClient.dynconfig.clientConfig }}
+    clientConfig:
+{{ toYaml .Values.seedClient.dynconfig.clientConfig | indent 6 }}
+    {{- end }}
+    {{- if .Values.seedClient.dynconfig.seedClientConfig }}
+    seedClientConfig:
+{{ toYaml .Values.seedClient.dynconfig.seedClientConfig | indent 6 }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/dragonfly/templates/seed-client/seed-client-statefulset.yaml
+++ b/charts/dragonfly/templates/seed-client/seed-client-statefulset.yaml
@@ -69,6 +69,7 @@ spec:
 {{ toYaml .Values.seedClient.hostAliases | indent 8 }}
       {{- end }}
       initContainers:
+      {{- if include "dragonfly.manager.enable" . }}
       - name: wait-for-manager
         image: {{ template "seedClient.initContainer.image" . }}
         imagePullPolicy: {{ .Values.seedClient.initContainer.image.pullPolicy }}
@@ -79,6 +80,14 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.seedClient.initContainer.resources | indent 10 }}
+      {{- else if .Values.scheduler.enable }}
+      - name: wait-for-scheduler
+        image: {{ template "seedClient.initContainer.image" . }}
+        imagePullPolicy: {{ .Values.seedClient.initContainer.image.pullPolicy }}
+        command: ['sh', '-c', 'until nslookup {{ template "dragonfly.scheduler.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} && nc -vz {{ template "dragonfly.scheduler.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} {{ .Values.scheduler.config.server.port }}; do echo waiting for scheduler; sleep 2; done;']
+        resources:
+{{ toYaml .Values.seedClient.initContainer.resources | indent 10 }}
+      {{- end }}
       containers:
       - name: seed-client
         image: {{ template "seedClient.image" . }}

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -63,7 +63,7 @@ readinessProbe:
 
 manager:
   # -- Enable manager.
-  enable: true
+  enable: false
   # -- Manager name.
   name: manager
   # -- Override manager name.
@@ -397,17 +397,13 @@ scheduler:
     limits:
       cpu: '8'
       memory: '16Gi'
+  # -- Scheduler service configuration. The scheduler service is headless, so that
+  # clients can discover all scheduler IPs via DNS.
   service:
-    # -- Service type.
-    type: ClusterIP
-    # -- Service clusterIP.
-    clusterIP: ''
     # -- Service labels.
     labels: {}
     # -- Service annotations.
     annotations: {}
-    # -- Service nodePort.
-    nodePort: ''
   # -- Pod priorityClassName.
   priorityClassName: ''
   # -- Node labels for pod assignment.
@@ -507,7 +503,7 @@ scheduler:
       # -- Retry scheduling limit times.
       retryLimit: 5
       # -- Retry scheduling interval.
-      retryInterval: 2s
+      retryInterval: 1s
       gc:
         # -- pieceDownloadTimeout is the timeout of downloading piece.
         pieceDownloadTimeout: 30m
@@ -573,6 +569,28 @@ scheduler:
     network:
       # -- enableIPv6 specifies whether to enable IPv6 networking.
       enableIPv6: false
+  # -- dynconfig is the local dynamic configuration (dynconfig.yaml) for the scheduler,
+  # delivered as a ConfigMap and mounted into the same directory as scheduler.yaml.
+  # It is only used when no manager is available (manager.enable is false and
+  # externalManager.host is empty), and it is refreshed periodically according to
+  # scheduler.config.dynconfig.refreshInterval.
+  dynconfig:
+    # -- applications is the applications configuration.
+    applications: []
+    # -- seedPeerClusterConfig is the seed peer cluster configuration.
+    seedPeerClusterConfig:
+      # -- loadLimit is the seed peer concurrent upload limit.
+      loadLimit: 2000
+    # -- schedulerClusterConfig is the scheduler cluster configuration.
+    schedulerClusterConfig:
+      # -- candidateParentLimit is the candidate parent limit for scheduling.
+      candidateParentLimit: 3
+      # -- filterParentLimit is the filter parent limit for scheduling.
+      filterParentLimit: 15
+    # -- schedulerClusterClientConfig is the client configuration.
+    schedulerClusterClientConfig:
+      # -- loadLimit is the peer concurrent upload limit.
+      loadLimit: 200
   metrics:
     # -- Enable scheduler metrics.
     enable: true
@@ -976,15 +994,6 @@ seedClient:
       #
       # -- bandwidthLimit is the default rate limit of the upload speed in GB/Mb/Kb per second, default is 50GB/s.
       bandwidthLimit: 50GB
-    manager:
-      # -- addr is manager address.
-      addr: ''
-    # # CA certificate file path for mTLS.
-    # caCert: /etc/ssl/certs/ca.crt
-    # # GRPC client certificate file path for mTLS.
-    # cert: /etc/ssl/certs/client.crt
-    # # GRPC client key file path for mTLS.
-    # key: /etc/ssl/private/client.pem
     scheduler:
       # -- announceInterval is the interval to announce peer to the scheduler.
       # Announcer will provide the scheduler with peer information for scheduling,
@@ -1234,6 +1243,25 @@ seedClient:
     network:
       # -- enableIPv6 specifies whether to enable IPv6 networking.
       enableIPv6: false
+  # -- dynconfig is the local dynamic configuration (dynconfig.yaml) for the seed client,
+  # delivered as a ConfigMap and mounted into the same directory as dfdaemon.yaml.
+  # It is only used when no manager is available (manager.enable is false and
+  # externalManager.host is empty), and it is refreshed periodically according to
+  # seedClient.config.dynconfig.refreshInterval.
+  dynconfig:
+    scheduler:
+      # -- addr is the address of the scheduler headless service with port, resolved via
+      # DNS to discover all scheduler IPs. If empty, it defaults to the scheduler
+      # headless service address of this chart.
+      addr: ''
+      # -- addrs is the static list of scheduler addresses with port
+      # (e.g. ['192.168.1.10:8002']). When non-empty, it takes precedence over addr.
+      addrs: []
+    # -- clientConfig is the block list configuration for clients running as normal peers,
+    # e.g. clientConfig: { blockList: { task: { download: { applications: [], urls: [], tags: [], priorities: [] } } } }.
+    clientConfig: {}
+    # -- seedClientConfig is the block list configuration for clients running as seed peers.
+    seedClientConfig: {}
   metrics:
     # -- Enable seed client metrics.
     enable: true
@@ -1593,15 +1621,6 @@ client:
       disableShared: false
       # -- bandwidthLimit is the default rate limit of the upload speed in GB/Mb/Kb per second, default is 50GB/s.
       bandwidthLimit: 50GB
-    manager:
-      # -- addr is manager address.
-      addr: ''
-    # # CA certificate file path for mTLS.
-    # caCert: /etc/ssl/certs/ca.crt
-    # # GRPC client certificate file path for mTLS.
-    # cert: /etc/ssl/certs/client.crt
-    # # GRPC client key file path for mTLS.
-    # key: /etc/ssl/private/client.pem
     scheduler:
       # -- announceInterval is the interval to announce peer to the scheduler.
       # Announcer will provide the scheduler with peer information for scheduling,
@@ -1848,6 +1867,25 @@ client:
     network:
       # -- enableIPv6 specifies whether to enable IPv6 networking.
       enableIPv6: false
+  # -- dynconfig is the local dynamic configuration (dynconfig.yaml) for the client,
+  # delivered as a ConfigMap and mounted into the same directory as dfdaemon.yaml.
+  # It is only used when no manager is available (manager.enable is false and
+  # externalManager.host is empty), and it is refreshed periodically according to
+  # client.config.dynconfig.refreshInterval.
+  dynconfig:
+    scheduler:
+      # -- addr is the address of the scheduler headless service with port, resolved via
+      # DNS to discover all scheduler IPs. If empty, it defaults to the scheduler
+      # headless service address of this chart.
+      addr: ''
+      # -- addrs is the static list of scheduler addresses with port
+      # (e.g. ['192.168.1.10:8002']). When non-empty, it takes precedence over addr.
+      addrs: []
+    # -- clientConfig is the block list configuration for clients running as normal peers,
+    # e.g. clientConfig: { blockList: { task: { download: { applications: [], urls: [], tags: [], priorities: [] } } } }.
+    clientConfig: {}
+    # -- seedClientConfig is the block list configuration for clients running as seed peers.
+    seedClientConfig: {}
   metrics:
     # -- Enable client metrics.
     enable: true
@@ -1905,15 +1943,15 @@ client:
 
 externalManager:
   # -- External manager hostname.
-  host:
+  host: ''
   # -- External REST service port.
   restPort: 8080
   # -- External GRPC service port.
   grpcPort: 65003
 
 mysql:
-  # -- Enable mysql with docker container.
-  enable: true
+  # -- Enable mysql with docker container, only used when the manager is deployed.
+  enable: false
   image:
     repository: bitnamilegacy/mysql
   # -- Cluster domain.
@@ -1951,8 +1989,8 @@ externalMysql:
   port: 3306
 
 redis:
-  # -- Enable redis cluster with docker container.
-  enable: true
+  # -- Enable redis cluster with docker container, only used when the manager is deployed.
+  enable: false
   image:
     repository: bitnamilegacy/redis
   # -- Cluster domain.
@@ -1969,9 +2007,10 @@ redis:
         redis: 6379
 
 externalRedis:
-  # -- External redis server addresses.
-  addrs:
-    - 'redis.example.com:6379'
+  # -- External redis server addresses (e.g. ['redis.example.com:6379']), required when
+  # the manager is deployed and redis.enable is false. If empty, the scheduler runs
+  # without redis and disables the redis-dependent features (e.g. job).
+  addrs: []
   # -- External redis sentinel master name.
   masterName: ''
   # -- External redis username.

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -81,7 +81,7 @@ manager:
     # -- Image repository.
     repository: dragonflyoss/manager
     # -- Image tag.
-    tag: v2.5.0
+    tag: v2.5.1
     # -- Image digest.
     digest: ''
     # -- Image pull policy.
@@ -377,7 +377,7 @@ scheduler:
     # -- Image repository.
     repository: dragonflyoss/scheduler
     # -- Image tag.
-    tag: v2.5.0
+    tag: v2.5.1
     # -- Image digest.
     digest: ''
     # -- Image pull policy.
@@ -780,7 +780,7 @@ seedClient:
     # -- Image repository.
     repository: dragonflyoss/client
     # -- Image tag.
-    tag: v1.4.0
+    tag: v1.4.3
     # -- Image digest.
     digest: ''
     # -- Image pull policy.
@@ -1335,7 +1335,7 @@ client:
     # -- Image repository.
     repository: dragonflyoss/client
     # -- Image tag.
-    tag: v1.4.0
+    tag: v1.4.3
     # -- Image digest.
     digest: ''
     # -- Image pull policy.
@@ -1424,7 +1424,7 @@ client:
       # -- Image repository.
       repository: dragonflyoss/dfinit
       # -- Image tag.
-      tag: v1.4.0
+      tag: v1.4.3
       # -- Image digest.
       digest: ''
       # -- Image pull policy.
@@ -2096,7 +2096,7 @@ injector:
     # -- Image repository.
     repository: dragonflyoss/client
     # -- Image tag. Should align with the version of Dragonfly client and seed client.
-    tag: v1.4.0
+    tag: v1.4.3
     # -- Image digest.
     digest: ''
     # -- Image pull policy.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces significant improvements to the Dragonfly Helm chart, focusing on supporting deployments without the manager component, updating images and versions, and enhancing configuration flexibility. The changes enable running Dragonfly in a "managerless" mode by delivering dynamic configuration via ConfigMaps and making the scheduler discoverable through a headless service. Additionally, the default deployment disables the manager, MySQL, and Redis, making these components optional unless explicitly enabled.

**Key changes:**

### Managerless deployment and dynamic configuration

* Added support for running Dragonfly without the manager: local dynamic configuration (`dynconfig.yaml`) for the scheduler, client, and seed client is now delivered as ConfigMaps and mounted into containers. The scheduler is exposed via a headless service for DNS-based discovery, and the manager deployment is disabled by default. (`charts/dragonfly/Chart.yaml`, `charts/dragonfly/README.md`, `charts/dragonfly/templates/NOTES.txt`, [[1]](diffhunk://#diff-25290d9a372e4981f1debbdab9be8d106ac2ddbbb611916171e82e64afe85d98R1-R4) [[2]](diffhunk://#diff-2ef1769f5a0d1331fb546001517de192703975da5fb91419b7caf6d94ec65a7eR1-R8) [[3]](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L30-R30) [[4]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR209-R213) [[5]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL361-R365) [[6]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL424-R428) [[7]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL439-R443) [[8]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR479-R487) [[9]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR529-L520) [[10]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL555) [[11]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR603-R607) [[12]](diffhunk://#diff-5d45c284cf9c7379635adb0b4cea91c8885948273208f0f2b4b8572fb261605dR1) [[13]](diffhunk://#diff-5d45c284cf9c7379635adb0b4cea91c8885948273208f0f2b4b8572fb261605dR16-R39)

* Updated documentation and configuration options to reflect the new dynamic configuration approach and clarify when manager, MySQL, and Redis are required. (`charts/dragonfly/README.md`, [[1]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR209-R213) [[2]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL361-R365) [[3]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL424-R428) [[4]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL439-R443) [[5]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR479-R487) [[6]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR529-L520) [[7]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL555) [[8]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR603-R607)

### Image and version updates

* Bumped chart version to `1.7.5` and app version to `2.5.1`. Updated all Dragonfly component images (`manager`, `scheduler`, `client`, `seed-client`, `dfinit`) to their respective latest versions. (`charts/dragonfly/Chart.yaml`, [[1]](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L6-R7) [[2]](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L40-R48)

### Default values and test configurations

* Changed the default values to disable the manager, MySQL, and Redis by default, and provided separate test values for enabling the manager stack. (`charts/dragonfly/ci/default-values.yaml`, `charts/dragonfly/ci/manager-values.yaml`, [[1]](diffhunk://#diff-25290d9a372e4981f1debbdab9be8d106ac2ddbbb611916171e82e64afe85d98R1-R4) [[2]](diffhunk://#diff-2ef1769f5a0d1331fb546001517de192703975da5fb91419b7caf6d94ec65a7eR1-R8)

### Configuration and documentation improvements

* Improved and clarified configuration documentation for dynamic configuration, external dependencies, and scheduler service discovery. Added and updated fields related to `dynconfig`, and made the scheduler service headless by default. (`charts/dragonfly/README.md`, [[1]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR209-R213) [[2]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR479-R487) [[3]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR529-L520)

* Updated user instructions in `NOTES.txt` to provide clear steps for all deployment modes (with manager, with external manager, and managerless). (`charts/dragonfly/templates/NOTES.txt`, [[1]](diffhunk://#diff-5d45c284cf9c7379635adb0b4cea91c8885948273208f0f2b4b8572fb261605dR1) [[2]](diffhunk://#diff-5d45c284cf9c7379635adb0b4cea91c8885948273208f0f2b4b8572fb261605dR16-R39)

These changes make the Dragonfly Helm chart more flexible, easier to operate in different environments, and better documented for both standard and advanced deployments.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
