### PR TITLE
feat: add optional privileged sysctl init container for client and seed client

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.7.7
+version: 1.7.8
 appVersion: 2.5.1
 keywords:
   - dragonfly
@@ -27,8 +27,9 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Fix disk misspelled as dist in gc policy configuration.
-    - Bump client version to v1.4.7.
+    - Add optional privileged sysctl init container for client and seed client.
+    - Declare client and seed client affinity values.
+    - Fix client daemonset annotations misspelled as statefulset annotations.
   artifacthub.io/links: |
     - name: Chart Source
       url: https://github.com/dragonflyoss/helm-charts

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -126,6 +126,7 @@ helm delete dragonfly --namespace dragonfly-system
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| client.affinity | object | `{}` | Pod affinity. |
 | client.config.backend.cacheTemporaryRedirectTTL | string | `"600s"` | cacheTemporaryRedirectTTL is the TTL for cached 307 redirect URLs. After this duration, the cached redirect target will expire and be re-resolved. |
 | client.config.backend.enableCacheTemporaryRedirect | bool | `true` | enableCacheTemporaryRedirect enables caching of 307 redirect URLs. Motivation: Dragonfly splits a download URL into multiple pieces and performs multiple requests. Without caching, each piece request may trigger the same 307 redirect again, repeating the redirect flow and adding extra latency. Caching the resolved redirect URL reduces repeated redirects and improves request performance. |
 | client.config.backend.maxRetries | int | `1` | The maximum number of retry attempts when a chunk request to the backend storage fails. Once this limit is reached, the request will be considered failed and an error will be returned. |
@@ -193,6 +194,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.config.upload.server.port | int | `4000` | port is the port to the grpc server. |
 | client.config.upload.server.requestRateLimit | int | `200` | requestRateLimit is the rate limit of the upload server's request in dfdaemon, default is 200 req/s.  This limit applies to the total number of gRPC requests per second, including: - Multiple requests within a single connection. - Single requests across different connections. |
 | client.config.upload.server.requestbufferSize | int | `1000` | requestbufferSize is the buffer size of the upload server's request channel in dfdaemon, default is 1000.  This controls the capacity of the bounded channel used to queue incoming gRPC requests before they are processed. If the buffer is full, new requests will return a `RESOURCE_EXHAUSTED` error. |
+| client.daemonsetAnnotations | object | `{}` | Daemonset annotations. |
 | client.dfinit.config.console | bool | `true` | console prints log. |
 | client.dfinit.config.containerRuntime.containerd.configPath | string | `"/etc/containerd/config.toml"` | configPath is the path of containerd configuration file. |
 | client.dfinit.config.containerRuntime.containerd.proxyAllRegistries | bool | `true` | Proxy all registries enables a catch-all `_default/hosts.toml` entry so that any registry not explicitly listed in `registries` is still proxied through dfdaemon. The dfdaemon infers the upstream registry from the `ns=` query parameter that containerd appends when using a `_default` fallback mirror. Explicitly configured registries continue to use their own `hosts.toml` and take precedence. |
@@ -231,7 +233,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.initContainer.image.registry | string | `"docker.io"` | Image registry. |
 | client.initContainer.image.repository | string | `"busybox"` | Image repository. |
 | client.initContainer.image.tag | string | `"latest"` | Image tag. |
-| client.initContainer.resources | object | `{"limits":{"cpu":"2","memory":"4Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits. |
+| client.initContainer.resources | object | `{"limits":{"cpu":"2","memory":"4Gi"},"requests":{"cpu":"250m","memory":"512Mi"}}` | Pod resource requests and limits. |
 | client.maxProcs | string | `""` | maxProcs Limits the number of operating system threads that can execute user-level. Go code simultaneously by setting GOMAXPROCS environment variable, refer to https://golang.org/pkg/runtime. |
 | client.metrics.enable | bool | `true` | Enable client metrics. |
 | client.metrics.prometheusRule.additionalLabels | object | `{}` | Additional labels. |
@@ -251,8 +253,9 @@ helm delete dragonfly --namespace dragonfly-system
 | client.podAnnotations | object | `{}` | Pod annotations. |
 | client.podLabels | object | `{}` | Pod labels. |
 | client.priorityClassName | string | `""` | Pod priorityClassName. |
-| client.resources | object | `{"limits":{"cpu":"4","memory":"8Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits. |
-| client.statefulsetAnnotations | object | `{}` | Statefulset annotations. |
+| client.resources | object | `{"limits":{"cpu":"4","memory":"8Gi"},"requests":{"cpu":"250m","memory":"512Mi"}}` | Pod resource requests and limits. |
+| client.sysctlInit.enable | bool | `false` | Enable a privileged init container that sets host sysctls, following the pattern of the Elasticsearch and OpenSearch charts. Requires hostNetwork for host-wide network sysctls, and is rejected in PodSecurity `restricted` namespaces. |
+| client.sysctlInit.sysctls | object | `{"net.core.rmem_max":"16777216","net.core.wmem_max":"16777216"}` | Sysctls to set, sized for the socket buffers by default. |
 | client.terminationGracePeriodSeconds | string | `nil` | Pod terminationGracePeriodSeconds. |
 | client.tolerations | list | `[]` | List of node taints to tolerate. |
 | client.updateStrategy | object | `{"rollingUpdate":{"maxSurge":0,"maxUnavailable":20},"type":"RollingUpdate"}` | Update strategy for replicas. |
@@ -317,7 +320,7 @@ helm delete dragonfly --namespace dragonfly-system
 | injector.podLabels | object | `{}` | Pod labels. |
 | injector.priorityClassName | string | `""` | Pod priorityClassName. |
 | injector.replicas | int | `2` | Number of Pods to launch. |
-| injector.resources | object | `{"limits":{"cpu":"2","memory":"4Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits. |
+| injector.resources | object | `{"limits":{"cpu":"2","memory":"4Gi"},"requests":{"cpu":"250m","memory":"512Mi"}}` | Pod resource requests and limits. |
 | injector.terminationGracePeriodSeconds | int | `10` | Pod terminationGracePeriodSeconds. |
 | injector.tolerations | list | `[]` | List of node taints to tolerate. |
 | injector.webhook.failurePolicy | string | `"Ignore"` | failurePolicy defines how unrecognized errors and timeout errors from the admission webhook are handled. Allowed values are "Ignore" or "Fail". |
@@ -388,7 +391,7 @@ helm delete dragonfly --namespace dragonfly-system
 | manager.initContainer.image.registry | string | `"docker.io"` | Image registry. |
 | manager.initContainer.image.repository | string | `"busybox"` | Image repository. |
 | manager.initContainer.image.tag | string | `"latest"` | Image tag. |
-| manager.initContainer.resources | object | `{"limits":{"cpu":"2","memory":"4Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits. |
+| manager.initContainer.resources | object | `{"limits":{"cpu":"2","memory":"4Gi"},"requests":{"cpu":"250m","memory":"512Mi"}}` | Pod resource requests and limits. |
 | manager.maxProcs | string | `""` | maxProcs Limits the number of operating system threads that can execute user-level. Go code simultaneously by setting GOMAXPROCS environment variable, refer to https://golang.org/pkg/runtime. |
 | manager.metrics.enable | bool | `true` | Enable manager metrics. |
 | manager.metrics.prometheusRule.additionalLabels | object | `{}` | Additional labels. |
@@ -409,7 +412,7 @@ helm delete dragonfly --namespace dragonfly-system
 | manager.podLabels | object | `{}` | Pod labels. |
 | manager.priorityClassName | string | `""` | Pod priorityClassName. |
 | manager.replicas | int | `3` | Number of Pods to launch. |
-| manager.resources | object | `{"limits":{"cpu":"8","memory":"16Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits. |
+| manager.resources | object | `{"limits":{"cpu":"8","memory":"16Gi"},"requests":{"cpu":"250m","memory":"512Mi"}}` | Pod resource requests and limits. |
 | manager.restPort | int | `8080` | REST service port. |
 | manager.service.annotations | object | `{}` | Service annotations. |
 | manager.service.clusterIP | string | `""` | Service clusterIP. |
@@ -503,7 +506,7 @@ helm delete dragonfly --namespace dragonfly-system
 | scheduler.initContainer.image.registry | string | `"docker.io"` | Image registry. |
 | scheduler.initContainer.image.repository | string | `"busybox"` | Image repository. |
 | scheduler.initContainer.image.tag | string | `"latest"` | Image tag. |
-| scheduler.initContainer.resources | object | `{"limits":{"cpu":"2","memory":"4Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits. |
+| scheduler.initContainer.resources | object | `{"limits":{"cpu":"2","memory":"4Gi"},"requests":{"cpu":"250m","memory":"512Mi"}}` | Pod resource requests and limits. |
 | scheduler.maxProcs | string | `""` | maxProcs Limits the number of operating system threads that can execute user-level. Go code simultaneously by setting GOMAXPROCS environment variable, refer to https://golang.org/pkg/runtime. |
 | scheduler.metrics.enable | bool | `true` | Enable scheduler metrics. |
 | scheduler.metrics.enableHost | bool | `false` | Enable host metrics. |
@@ -525,7 +528,7 @@ helm delete dragonfly --namespace dragonfly-system
 | scheduler.podLabels | object | `{}` | Pod labels. |
 | scheduler.priorityClassName | string | `""` | Pod priorityClassName. |
 | scheduler.replicas | int | `3` | Number of Pods to launch. |
-| scheduler.resources | object | `{"limits":{"cpu":"8","memory":"16Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits. |
+| scheduler.resources | object | `{"limits":{"cpu":"8","memory":"16Gi"},"requests":{"cpu":"250m","memory":"512Mi"}}` | Pod resource requests and limits. |
 | scheduler.service | object | `{"annotations":{},"labels":{}}` | Scheduler service configuration. The scheduler service is headless, so that clients can discover all scheduler IPs via DNS. |
 | scheduler.service.annotations | object | `{}` | Service annotations. |
 | scheduler.service.labels | object | `{}` | Service labels. |
@@ -533,6 +536,7 @@ helm delete dragonfly --namespace dragonfly-system
 | scheduler.terminationGracePeriodSeconds | string | `nil` | Pod terminationGracePeriodSeconds. |
 | scheduler.tolerations | list | `[]` | List of node taints to tolerate. |
 | scheduler.updateStrategy | object | `{}` | Update strategy for replicas. |
+| seedClient.affinity | object | `{}` | Pod affinity. |
 | seedClient.config.backend.cacheTemporaryRedirectTTL | string | `"600s"` | cacheTemporaryRedirectTTL is the TTL for cached 307 redirect URLs. After this duration, the cached redirect target will expire and be re-resolved. |
 | seedClient.config.backend.enableCacheTemporaryRedirect | bool | `true` | enableCacheTemporaryRedirect enables caching of 307 redirect URLs. Motivation: Dragonfly splits a download URL into multiple pieces and performs multiple requests. Without caching, each piece request may trigger the same 307 redirect again, repeating the redirect flow and adding extra latency. Caching the resolved redirect URL reduces repeated redirects and improves request performance. |
 | seedClient.config.backend.maxRetries | int | `1` | The maximum number of retry attempts when a chunk request to the backend storage fails. Once this limit is reached, the request will be considered failed and an error will be returned. |
@@ -623,7 +627,7 @@ helm delete dragonfly --namespace dragonfly-system
 | seedClient.initContainer.image.registry | string | `"docker.io"` | Image registry. |
 | seedClient.initContainer.image.repository | string | `"busybox"` | Image repository. |
 | seedClient.initContainer.image.tag | string | `"latest"` | Image tag. |
-| seedClient.initContainer.resources | object | `{"limits":{"cpu":"2","memory":"4Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits. |
+| seedClient.initContainer.resources | object | `{"limits":{"cpu":"2","memory":"4Gi"},"requests":{"cpu":"250m","memory":"512Mi"}}` | Pod resource requests and limits. |
 | seedClient.maxProcs | string | `""` | maxProcs Limits the number of operating system threads that can execute user-level. Go code simultaneously by setting GOMAXPROCS environment variable, refer to https://golang.org/pkg/runtime. |
 | seedClient.metrics.enable | bool | `true` | Enable seed client metrics. |
 | seedClient.metrics.prometheusRule.additionalLabels | object | `{}` | Additional labels. |
@@ -649,13 +653,15 @@ helm delete dragonfly --namespace dragonfly-system
 | seedClient.podLabels | object | `{}` | Pod labels. |
 | seedClient.priorityClassName | string | `""` | Pod priorityClassName. |
 | seedClient.replicas | int | `3` | Number of Pods to launch. |
-| seedClient.resources | object | `{"limits":{"cpu":"8","memory":"16Gi"},"requests":{"cpu":"0","memory":"0"}}` | Pod resource requests and limits. |
+| seedClient.resources | object | `{"limits":{"cpu":"8","memory":"16Gi"},"requests":{"cpu":"8","memory":"16Gi"}}` | Pod resource requests and limits. |
 | seedClient.service.annotations | object | `{}` | Service annotations. |
 | seedClient.service.clusterIP | string | `""` | Service clusterIP. |
 | seedClient.service.labels | object | `{}` | Service labels. |
 | seedClient.service.nodePort | string | `""` | Service nodePort. |
 | seedClient.service.type | string | `"ClusterIP"` | Service type. |
 | seedClient.statefulsetAnnotations | object | `{}` | Statefulset annotations. |
+| seedClient.sysctlInit.enable | bool | `false` | Enable a privileged init container that sets host sysctls, following the pattern of the Elasticsearch and OpenSearch charts. Network sysctls apply to the pod network namespace unless hostNetwork is enabled, and privileged containers are rejected in PodSecurity `restricted` namespaces. |
+| seedClient.sysctlInit.sysctls | object | `{"net.core.rmem_max":"16777216","net.core.wmem_max":"16777216"}` | Sysctls to set, sized for the QUIC socket buffers by default. |
 | seedClient.terminationGracePeriodSeconds | string | `nil` | Pod terminationGracePeriodSeconds. |
 | seedClient.tolerations | list | `[]` | List of node taints to tolerate. |
 | seedClient.updateStrategy | object | `{}` | Update strategy for replicas. |

--- a/charts/dragonfly/ci/default-values.yaml
+++ b/charts/dragonfly/ci/default-values.yaml
@@ -1,4 +1,38 @@
 # Chart-testing (ct lint/install) values: install with the default values, which run
 # Dragonfly without the manager, and the scheduler and client load the dynamic
 # configuration from the local dynconfig.yaml file mounted as a ConfigMap.
-{}
+scheduler:
+  resources:
+    requests:
+      cpu: '0'
+      memory: '0'
+  initContainer:
+    resources:
+      requests:
+        cpu: '0'
+        memory: '0'
+seedClient:
+  resources:
+    requests:
+      cpu: '0'
+      memory: '0'
+  initContainer:
+    resources:
+      requests:
+        cpu: '0'
+        memory: '0'
+client:
+  resources:
+    requests:
+      cpu: '0'
+      memory: '0'
+  initContainer:
+    resources:
+      requests:
+        cpu: '0'
+        memory: '0'
+injector:
+  resources:
+    requests:
+      cpu: '0'
+      memory: '0'

--- a/charts/dragonfly/ci/manager-values.yaml
+++ b/charts/dragonfly/ci/manager-values.yaml
@@ -2,7 +2,51 @@
 # including the mysql and redis dependencies required by the manager.
 manager:
   enable: true
+  resources:
+    requests:
+      cpu: '0'
+      memory: '0'
+  initContainer:
+    resources:
+      requests:
+        cpu: '0'
+        memory: '0'
 mysql:
   enable: true
 redis:
   enable: true
+scheduler:
+  resources:
+    requests:
+      cpu: '0'
+      memory: '0'
+  initContainer:
+    resources:
+      requests:
+        cpu: '0'
+        memory: '0'
+seedClient:
+  resources:
+    requests:
+      cpu: '0'
+      memory: '0'
+  initContainer:
+    resources:
+      requests:
+        cpu: '0'
+        memory: '0'
+client:
+  resources:
+    requests:
+      cpu: '0'
+      memory: '0'
+  initContainer:
+    resources:
+      requests:
+        cpu: '0'
+        memory: '0'
+injector:
+  resources:
+    requests:
+      cpu: '0'
+      memory: '0'

--- a/charts/dragonfly/templates/client/client-daemonset.yaml
+++ b/charts/dragonfly/templates/client/client-daemonset.yaml
@@ -72,6 +72,23 @@ spec:
 {{ toYaml .Values.client.hostAliases | indent 8 }}
       {{- end }}
       initContainers:
+      {{- if .Values.client.sysctlInit.enable }}
+      - name: sysctl
+        image: {{ template "client.initContainer.image" . }}
+        imagePullPolicy: {{ .Values.client.initContainer.image.pullPolicy }}
+        securityContext:
+          # Sysctl needs privilege permission.
+          privileged: true
+        command:
+        - /bin/sh
+        - -cx
+        - |-
+          {{- range $key, $value := .Values.client.sysctlInit.sysctls }}
+          sysctl -w {{ $key }}={{ $value }}
+          {{- end }}
+        resources:
+{{ toYaml .Values.client.initContainer.resources | indent 10 }}
+      {{- end }}
       {{- if .Values.scheduler.enable }}
       - name: wait-for-scheduler
         image: {{ template "client.initContainer.image" . }}

--- a/charts/dragonfly/templates/seed-client/seed-client-statefulset.yaml
+++ b/charts/dragonfly/templates/seed-client/seed-client-statefulset.yaml
@@ -69,6 +69,23 @@ spec:
 {{ toYaml .Values.seedClient.hostAliases | indent 8 }}
       {{- end }}
       initContainers:
+      {{- if .Values.seedClient.sysctlInit.enable }}
+      - name: sysctl
+        image: {{ template "seedClient.initContainer.image" . }}
+        imagePullPolicy: {{ .Values.seedClient.initContainer.image.pullPolicy }}
+        securityContext:
+          # Sysctl needs privilege permission.
+          privileged: true
+        command:
+        - /bin/sh
+        - -cx
+        - |-
+          {{- range $key, $value := .Values.seedClient.sysctlInit.sysctls }}
+          sysctl -w {{ $key }}={{ $value }}
+          {{- end }}
+        resources:
+{{ toYaml .Values.seedClient.initContainer.resources | indent 10 }}
+      {{- end }}
       {{- if include "dragonfly.manager.enable" . }}
       - name: wait-for-manager
         image: {{ template "seedClient.initContainer.image" . }}

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -96,8 +96,8 @@ manager:
   # -- Pod resource requests and limits.
   resources:
     requests:
-      cpu: '0'
-      memory: '0'
+      cpu: '250m'
+      memory: '512Mi'
     limits:
       cpu: '8'
       memory: '16Gi'
@@ -147,8 +147,8 @@ manager:
     # -- Pod resource requests and limits.
     resources:
       requests:
-        cpu: '0'
-        memory: '0'
+        cpu: '250m'
+        memory: '512Mi'
       limits:
         cpu: '2'
         memory: '4Gi'
@@ -392,8 +392,8 @@ scheduler:
   # -- Pod resource requests and limits.
   resources:
     requests:
-      cpu: '0'
-      memory: '0'
+      cpu: '250m'
+      memory: '512Mi'
     limits:
       cpu: '8'
       memory: '16Gi'
@@ -436,8 +436,8 @@ scheduler:
     # -- Pod resource requests and limits.
     resources:
       requests:
-        cpu: '0'
-        memory: '0'
+        cpu: '250m'
+        memory: '512Mi'
       limits:
         cpu: '2'
         memory: '4Gi'
@@ -795,8 +795,8 @@ seedClient:
   # -- Pod resource requests and limits.
   resources:
     requests:
-      cpu: '0'
-      memory: '0'
+      cpu: '8'
+      memory: '16Gi'
     limits:
       cpu: '8'
       memory: '16Gi'
@@ -804,6 +804,19 @@ seedClient:
   priorityClassName: ''
   # -- Node labels for pod assignment.
   nodeSelector: {}
+  # -- Pod affinity.
+  affinity: {}
+  sysctlInit:
+    # -- Enable a privileged init container that sets host sysctls, following
+    # the pattern of the Elasticsearch and OpenSearch charts. Network sysctls
+    # apply to the pod network namespace unless hostNetwork is enabled, and
+    # privileged containers are rejected in PodSecurity `restricted`
+    # namespaces.
+    enable: false
+    # -- Sysctls to set, sized for the QUIC socket buffers by default.
+    sysctls:
+      net.core.rmem_max: '16777216'
+      net.core.wmem_max: '16777216'
   # -- Pod terminationGracePeriodSeconds.
   terminationGracePeriodSeconds:
   # -- List of node taints to tolerate.
@@ -820,8 +833,8 @@ seedClient:
     # -- Pod resource requests and limits.
     resources:
       requests:
-        cpu: '0'
-        memory: '0'
+        cpu: '250m'
+        memory: '512Mi'
       limits:
         cpu: '2'
         memory: '4Gi'
@@ -1354,8 +1367,8 @@ client:
   # -- Pod resource requests and limits.
   resources:
     requests:
-      cpu: '0'
-      memory: '0'
+      cpu: '250m'
+      memory: '512Mi'
     limits:
       cpu: '4'
       memory: '8Gi'
@@ -1363,6 +1376,8 @@ client:
   priorityClassName: ''
   # -- Node labels for pod assignment.
   nodeSelector: {}
+  # -- Pod affinity.
+  affinity: {}
   # -- Pod terminationGracePeriodSeconds.
   terminationGracePeriodSeconds:
   # -- List of node taints to tolerate.
@@ -1377,14 +1392,24 @@ client:
     rollingUpdate:
       maxSurge: 0
       maxUnavailable: 20
-  # -- Statefulset annotations.
-  statefulsetAnnotations: {}
+  # -- Daemonset annotations.
+  daemonsetAnnotations: {}
+  sysctlInit:
+    # -- Enable a privileged init container that sets host sysctls, following
+    # the pattern of the Elasticsearch and OpenSearch charts. Requires
+    # hostNetwork for host-wide network sysctls, and is rejected in
+    # PodSecurity `restricted` namespaces.
+    enable: false
+    # -- Sysctls to set, sized for the socket buffers by default.
+    sysctls:
+      net.core.rmem_max: '16777216'
+      net.core.wmem_max: '16777216'
   initContainer:
     # -- Pod resource requests and limits.
     resources:
       requests:
-        cpu: '0'
-        memory: '0'
+        cpu: '250m'
+        memory: '512Mi'
       limits:
         cpu: '2'
         memory: '4Gi'
@@ -2061,8 +2086,8 @@ injector:
   # -- Pod resource requests and limits.
   resources:
     requests:
-      cpu: '0'
-      memory: '0'
+      cpu: '250m'
+      memory: '512Mi'
     limits:
       cpu: '2'
       memory: '4Gi'


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

This pull request updates the Dragonfly Helm chart to version 1.7.8 and introduces several enhancements and fixes, mainly around the configurability and deployment flexibility of the client and seed client components. The most important changes include adding optional privileged sysctl init containers, introducing pod affinity settings, improving resource request defaults, and fixing annotation configuration.

**Deployment and Configuration Enhancements:**

* Added an optional privileged `sysctl` init container for both `client` and `seedClient`, allowing custom sysctl settings to be applied at pod startup. This is controlled via the new `sysctlInit.enable` and `sysctlInit.sysctls` values. [[1]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL1380-R1409) [[2]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL798-R819) [[3]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL1354-R1370) [[4]](diffhunk://#diff-8cf66934693161309da9877cfb771789762f3385911bfbef625d3990182de2f9R75-R91) [[5]](diffhunk://#diff-6d654bfeacaa663ab0bcb823c3429c8dae1c469d46a9c8d6032ab065b471a1a9R72-R88) [[6]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL254-R258) [[7]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL652-R664)
* Introduced `affinity` configuration for both `client` and `seedClient`, enabling users to specify pod affinity rules. [[1]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bR1382-R1383) [[2]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL798-R819) [[3]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR129) [[4]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR539)

**Resource and Annotation Improvements:**

* Updated the default `seedClient.resources.requests` to match its limits (`cpu: 8`, `memory: 16Gi`), ensuring a Guaranteed QoS class by default. [[1]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL798-R819) [[2]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL652-R664)
* Changed `client.statefulsetAnnotations` to `client.daemonsetAnnotations` and fixed its description, correcting a previous mislabeling. [[1]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL1380-R1409) [[2]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR197) [[3]](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L30-R32)

**Documentation and Metadata:**

* Updated documentation in `README.md` and chart annotations to reflect the new options and fixes. [[1]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR129) [[2]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR197) [[3]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL254-R258) [[4]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR539) [[5]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL652-R664) [[6]](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L30-R32)
* Bumped chart version to `1.7.8`.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
