### PR TITLE
feat: configure shared JWT authentication

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Run chart-testing (lint)
         run: ct lint --config ./.github/ct.yaml
 
+      - name: Test gRPC JWT authentication rendering
+        run: bash ./charts/dragonfly/tests/grpc-auth-render.sh
+
       - name: Create kind cluster
         uses: helm/kind-action@v1.14.0
         if: steps.list-changed.outputs.changed == 'true'

--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.7.8
+version: 1.7.9
 appVersion: 2.5.1
 keywords:
   - dragonfly
@@ -27,9 +27,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Add optional privileged sysctl init container for client and seed client.
-    - Declare client and seed client affinity values.
-    - Fix client daemonset annotations misspelled as statefulset annotations.
+    - Add opt-in JWT authentication for inter-component gRPC calls using an existing Kubernetes Secret.
   artifacthub.io/links: |
     - name: Chart Source
       url: https://github.com/dragonflyoss/helm-charts

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -114,6 +114,36 @@ helm repo add dragonfly https://dragonflyoss.github.io/helm-charts/
 helm install --create-namespace --namespace dragonfly-system dragonfly dragonfly/dragonfly -f values.yaml
 ```
 
+### Enable inter-component gRPC JWT authentication
+
+Authentication is disabled by default. In `disabled` mode the chart renders no gRPC authentication configuration or Secret mounts, so a normal chart and application upgrade preserves the legacy unauthenticated behavior.
+
+Use a single pre-existing Kubernetes Secret for Manager, Scheduler, Seed Client, and Client. The Secret value must contain standard Base64 text that decodes to at least 32 random bytes:
+
+```shell
+JWT_SECRET="$(openssl rand -base64 32)"
+kubectl create secret generic dragonfly-grpc-auth \
+  --namespace dragonfly-system \
+  --from-literal=secret="${JWT_SECRET}"
+unset JWT_SECRET
+```
+
+For the first authenticated rollout, use application images that support gRPC JWT authentication and set the global mode to `permissive`:
+
+```yaml
+grpcAuth:
+  mode: permissive
+  existingSecret: dragonfly-grpc-auth
+```
+
+During this rolling update, upgraded callers send JWTs and upgraded servers accept both authenticated requests and requests from Pods that have not yet been upgraded. Older servers ignore the additional gRPC metadata. After every component and external caller is upgraded, verify that authentication metrics no longer report expected business requests without credentials, then change the single global `grpcAuth.mode` to `required`.
+
+The transition from `permissive` to `required` is also safe during a rolling update: callers in both modes send JWTs, and servers in both modes accept valid JWTs. Once a cluster is running in `required` mode, later application upgrades keep that mode and use the normal one-step rolling upgrade. Roll back an enforcement change by returning to `permissive` before disabling authentication.
+
+The chart mounts the Secret read-only and writes only its file path to component ConfigMaps; it never copies secret material into Helm values or ConfigMaps. Set `requireTransportSecurity: true` only after TLS is enabled for every inter-component gRPC connection.
+
+For key rotation, add the new Base64 value as another data entry in the same Secret and append a matching item to `grpcAuth.keys`. Roll out once with the old `activeKeyID`, then switch `activeKeyID` and roll out again; keep the old entry until the maximum token lifetime and clock-skew window has elapsed.
+
 ## Uninstall
 
 Uninstall the `dragonfly` deployment:
@@ -288,6 +318,18 @@ helm delete dragonfly --namespace dragonfly-system
 | global.imageRegistry | string | `""` | Global Docker image registry. |
 | global.nodeSelector | object | `{}` | Global node labels for pod assignment. |
 | global.storageClass | string | `""` | Global storageClass for Persistent Volume(s). |
+| grpcAuth | object | `{"activeKeyID":"default","clockSkew":"30s","existingSecret":"","issuer":"dragonfly-internal","keys":[{"id":"default","secretKey":"secret"}],"maxTokenTTL":"15m","mode":"disabled","mountPath":"/etc/dragonfly/grpc-auth","refreshBefore":"1m","requireTransportSecurity":false,"tokenTTL":"10m"}` | Shared JWT authentication for inter-component gRPC calls. Disabled mode preserves the legacy behavior and renders no auth configuration or Secret mounts. For the first authenticated rollout, use permissive before required. The chart never creates or stores the key: create one Kubernetes Secret and reference it here. |
+| grpcAuth.activeKeyID | string | `"default"` | ID of the key used to sign new JWTs. |
+| grpcAuth.clockSkew | string | `"30s"` | Allowed clock skew when validating JWT timestamps. |
+| grpcAuth.existingSecret | string | `""` | Name of an existing Secret in the release namespace. Required when mode is not disabled. |
+| grpcAuth.issuer | string | `"dragonfly-internal"` | JWT issuer shared by all Dragonfly components. |
+| grpcAuth.keys | list | `[{"id":"default","secretKey":"secret"}]` | Trusted keys stored as data entries in existingSecret. Keep old and new entries during rotation. |
+| grpcAuth.maxTokenTTL | string | `"15m"` | Maximum accepted JWT lifetime. |
+| grpcAuth.mode | string | `"disabled"` | Authentication mode: disabled, permissive, or required. Permissive sends JWTs but accepts callers without one so old and new Pods can coexist during the first authenticated rolling upgrade. |
+| grpcAuth.mountPath | string | `"/etc/dragonfly/grpc-auth"` | Directory used to mount the shared key read-only. |
+| grpcAuth.refreshBefore | string | `"1m"` | Regenerate a cached token this long before expiration. |
+| grpcAuth.requireTransportSecurity | bool | `false` | Refuse to send JWTs over plaintext gRPC transports. |
+| grpcAuth.tokenTTL | string | `"10m"` | Lifetime of newly issued component JWTs. |
 | injector.affinity | object | `{}` | Pod affinity. |
 | injector.certManager | object | `{"enable":true,"issuer":{"create":true,"kind":"Issuer","name":""}}` | certManager configuration for webhook TLS certificates. cert-manager must be installed in the cluster. |
 | injector.certManager.enable | bool | `true` | Enable cert-manager integration for automatic TLS certificate management. |

--- a/charts/dragonfly/README.md.gotmpl
+++ b/charts/dragonfly/README.md.gotmpl
@@ -114,6 +114,36 @@ helm repo add dragonfly https://dragonflyoss.github.io/helm-charts/
 helm install --create-namespace --namespace dragonfly-system dragonfly dragonfly/dragonfly -f values.yaml
 ```
 
+### Enable inter-component gRPC JWT authentication
+
+Authentication is disabled by default. In `disabled` mode the chart renders no gRPC authentication configuration or Secret mounts, so a normal chart and application upgrade preserves the legacy unauthenticated behavior.
+
+Use a single pre-existing Kubernetes Secret for Manager, Scheduler, Seed Client, and Client. The Secret value must contain standard Base64 text that decodes to at least 32 random bytes:
+
+```shell
+JWT_SECRET="$(openssl rand -base64 32)"
+kubectl create secret generic dragonfly-grpc-auth \
+  --namespace dragonfly-system \
+  --from-literal=secret="${JWT_SECRET}"
+unset JWT_SECRET
+```
+
+For the first authenticated rollout, use application images that support gRPC JWT authentication and set the global mode to `permissive`:
+
+```yaml
+grpcAuth:
+  mode: permissive
+  existingSecret: dragonfly-grpc-auth
+```
+
+During this rolling update, upgraded callers send JWTs and upgraded servers accept both authenticated requests and requests from Pods that have not yet been upgraded. Older servers ignore the additional gRPC metadata. After every component and external caller is upgraded, verify that authentication metrics no longer report expected business requests without credentials, then change the single global `grpcAuth.mode` to `required`.
+
+The transition from `permissive` to `required` is also safe during a rolling update: callers in both modes send JWTs, and servers in both modes accept valid JWTs. Once a cluster is running in `required` mode, later application upgrades keep that mode and use the normal one-step rolling upgrade. Roll back an enforcement change by returning to `permissive` before disabling authentication.
+
+The chart mounts the Secret read-only and writes only its file path to component ConfigMaps; it never copies secret material into Helm values or ConfigMaps. Set `requireTransportSecurity: true` only after TLS is enabled for every inter-component gRPC connection.
+
+For key rotation, add the new Base64 value as another data entry in the same Secret and append a matching item to `grpcAuth.keys`. Roll out once with the old `activeKeyID`, then switch `activeKeyID` and roll out again; keep the old entry until the maximum token lifetime and clock-skew window has elapsed.
+
 ## Uninstall
 
 Uninstall the `dragonfly` deployment:

--- a/charts/dragonfly/templates/_helpers.tpl
+++ b/charts/dragonfly/templates/_helpers.tpl
@@ -212,6 +212,52 @@ Usage:
 {{- end -}}
 
 {{/*
+Render the shared inter-component gRPC JWT authentication configuration.
+*/}}
+{{- define "dragonfly.grpcAuth.config" -}}
+{{- $mode := lower .Values.grpcAuth.mode -}}
+{{- if not (has $mode (list "disabled" "permissive" "required")) -}}
+{{- fail "grpcAuth.mode must be one of disabled, permissive, or required" -}}
+{{- end -}}
+mode: {{ $mode | quote }}
+{{ if ne $mode "disabled" }}
+{{- $existingSecret := required "grpcAuth.existingSecret is required when gRPC authentication is enabled" .Values.grpcAuth.existingSecret -}}
+{{- $activeKeyID := required "grpcAuth.activeKeyID is required when gRPC authentication is enabled" .Values.grpcAuth.activeKeyID -}}
+{{- $mountPath := required "grpcAuth.mountPath is required when gRPC authentication is enabled" .Values.grpcAuth.mountPath -}}
+{{- if eq (len .Values.grpcAuth.keys) 0 -}}
+{{- fail "grpcAuth.keys must contain at least one key when gRPC authentication is enabled" -}}
+{{- end -}}
+requireTransportSecurity: {{ .Values.grpcAuth.requireTransportSecurity }}
+jwt:
+  issuer: {{ .Values.grpcAuth.issuer | quote }}
+  activeKeyID: {{ $activeKeyID | quote }}
+  tokenTTL: {{ .Values.grpcAuth.tokenTTL | quote }}
+  maxTokenTTL: {{ .Values.grpcAuth.maxTokenTTL | quote }}
+  clockSkew: {{ .Values.grpcAuth.clockSkew | quote }}
+  refreshBefore: {{ .Values.grpcAuth.refreshBefore | quote }}
+  keys:
+{{- $seen := dict -}}
+{{- $activeFound := false -}}
+{{- range $index, $key := .Values.grpcAuth.keys }}
+{{- $id := required "every grpcAuth.keys entry requires id" $key.id -}}
+{{- $secretKey := required "every grpcAuth.keys entry requires secretKey" $key.secretKey -}}
+{{- if hasKey $seen $id -}}
+{{- fail (printf "grpcAuth key id %q is duplicated" $id) -}}
+{{- end -}}
+{{- $_ := set $seen $id true -}}
+{{- if eq $id $activeKeyID -}}
+{{- $activeFound = true -}}
+{{- end }}
+    - id: {{ $id | quote }}
+      secretFile: {{ printf "%s/key-%d" (trimSuffix "/" $mountPath) $index | quote }}
+{{- end -}}
+{{- if not $activeFound -}}
+{{- fail "grpcAuth.activeKeyID must identify an entry in grpcAuth.keys" -}}
+{{- end -}}
+{{- end }}
+{{- end -}}
+
+{{/*
 Create a default fully qualified injector name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/charts/dragonfly/templates/client/client-configmap.yaml
+++ b/charts/dragonfly/templates/client/client-configmap.yaml
@@ -11,6 +11,10 @@ metadata:
     component: {{ .Values.client.name }}
 data:
   dfdaemon.yaml: |-
+    {{- if ne (lower .Values.grpcAuth.mode) "disabled" }}
+    grpcAuth:
+{{ include "dragonfly.grpcAuth.config" . | indent 6 }}
+    {{- end }}
     host:
 {{ toYaml .Values.client.config.host | indent 6 }}
     server:

--- a/charts/dragonfly/templates/client/client-daemonset.yaml
+++ b/charts/dragonfly/templates/client/client-daemonset.yaml
@@ -224,6 +224,11 @@ spec:
         volumeMounts:
         - name: config
           mountPath: "/etc/dragonfly"
+        {{- if ne (lower .Values.grpcAuth.mode) "disabled" }}
+        - name: grpc-auth
+          mountPath: {{ .Values.grpcAuth.mountPath | quote }}
+          readOnly: true
+        {{- end }}
         - name: socket-dir
           mountPath: /var/run/dragonfly
         {{- if .Values.client.extraVolumeMounts }}
@@ -233,6 +238,17 @@ spec:
       - name: config
         configMap:
           name: {{ template "dragonfly.client.fullname" . }}
+      {{- if ne (lower .Values.grpcAuth.mode) "disabled" }}
+      - name: grpc-auth
+        secret:
+          secretName: {{ required "grpcAuth.existingSecret is required when gRPC authentication is enabled" .Values.grpcAuth.existingSecret | quote }}
+          defaultMode: 0400
+          items:
+          {{- range $index, $key := .Values.grpcAuth.keys }}
+          - key: {{ $key.secretKey | quote }}
+            path: key-{{ $index }}
+          {{- end }}
+      {{- end }}
       - name: socket-dir
         hostPath:
           path: /var/run/dragonfly

--- a/charts/dragonfly/templates/manager/manager-configmap.yaml
+++ b/charts/dragonfly/templates/manager/manager-configmap.yaml
@@ -11,6 +11,10 @@ metadata:
     component: {{ .Values.manager.name }}
 data:
   manager.yaml: |-
+    {{- if ne (lower .Values.grpcAuth.mode) "disabled" }}
+    grpcAuth:
+{{ include "dragonfly.grpcAuth.config" . | indent 6 }}
+    {{- end }}
     server:
       rest:
         addr: :{{ .Values.manager.restPort }}

--- a/charts/dragonfly/templates/manager/manager-deployment.yaml
+++ b/charts/dragonfly/templates/manager/manager-deployment.yaml
@@ -111,6 +111,11 @@ spec:
         volumeMounts:
         - name: config
           mountPath: "/etc/dragonfly"
+        {{- if ne (lower .Values.grpcAuth.mode) "disabled" }}
+        - name: grpc-auth
+          mountPath: {{ .Values.grpcAuth.mountPath | quote }}
+          readOnly: true
+        {{- end }}
         {{- if .Values.manager.extraVolumeMounts }}
         {{- toYaml .Values.manager.extraVolumeMounts | nindent 8 }}
         {{- end }}
@@ -147,6 +152,17 @@ spec:
           items:
           - key: manager.yaml
             path: manager.yaml
+      {{- if ne (lower .Values.grpcAuth.mode) "disabled" }}
+      - name: grpc-auth
+        secret:
+          secretName: {{ required "grpcAuth.existingSecret is required when gRPC authentication is enabled" .Values.grpcAuth.existingSecret | quote }}
+          defaultMode: 0400
+          items:
+          {{- range $index, $key := .Values.grpcAuth.keys }}
+          - key: {{ $key.secretKey | quote }}
+            path: key-{{ $index }}
+          {{- end }}
+      {{- end }}
       {{- if .Values.manager.extraVolumes }}
       {{- toYaml .Values.manager.extraVolumes | nindent 6 }}
       {{- end }}

--- a/charts/dragonfly/templates/scheduler/scheduler-configmap.yaml
+++ b/charts/dragonfly/templates/scheduler/scheduler-configmap.yaml
@@ -11,6 +11,10 @@ metadata:
     component: {{ .Values.scheduler.name }}
 data:
   scheduler.yaml: |-
+    {{- if ne (lower .Values.grpcAuth.mode) "disabled" }}
+    grpcAuth:
+{{ include "dragonfly.grpcAuth.config" . | indent 6 }}
+    {{- end }}
     server:
 {{ toYaml .Values.scheduler.config.server | indent 6 }}
     scheduler:

--- a/charts/dragonfly/templates/scheduler/scheduler-statefulset.yaml
+++ b/charts/dragonfly/templates/scheduler/scheduler-statefulset.yaml
@@ -105,6 +105,11 @@ spec:
         volumeMounts:
         - name: config
           mountPath: "/etc/dragonfly"
+        {{- if ne (lower .Values.grpcAuth.mode) "disabled" }}
+        - name: grpc-auth
+          mountPath: {{ .Values.grpcAuth.mountPath | quote }}
+          readOnly: true
+        {{- end }}
         {{- if .Values.scheduler.extraVolumeMounts }}
         {{- toYaml .Values.scheduler.extraVolumeMounts | nindent 8 }}
         {{- end }}
@@ -145,6 +150,17 @@ spec:
           - key: dynconfig.yaml
             path: dynconfig.yaml
           {{- end }}
+      {{- if ne (lower .Values.grpcAuth.mode) "disabled" }}
+      - name: grpc-auth
+        secret:
+          secretName: {{ required "grpcAuth.existingSecret is required when gRPC authentication is enabled" .Values.grpcAuth.existingSecret | quote }}
+          defaultMode: 0400
+          items:
+          {{- range $index, $key := .Values.grpcAuth.keys }}
+          - key: {{ $key.secretKey | quote }}
+            path: key-{{ $index }}
+          {{- end }}
+      {{- end }}
       {{- if .Values.scheduler.extraVolumes }}
       {{- toYaml .Values.scheduler.extraVolumes | nindent 6 }}
       {{- end }}

--- a/charts/dragonfly/templates/seed-client/seed-client-configmap.yaml
+++ b/charts/dragonfly/templates/seed-client/seed-client-configmap.yaml
@@ -11,6 +11,10 @@ metadata:
     component: {{ .Values.seedClient.name }}
 data:
   dfdaemon.yaml: |-
+    {{- if ne (lower .Values.grpcAuth.mode) "disabled" }}
+    grpcAuth:
+{{ include "dragonfly.grpcAuth.config" . | indent 6 }}
+    {{- end }}
     host:
 {{ toYaml .Values.seedClient.config.host | indent 6 }}
     server:

--- a/charts/dragonfly/templates/seed-client/seed-client-statefulset.yaml
+++ b/charts/dragonfly/templates/seed-client/seed-client-statefulset.yaml
@@ -176,6 +176,11 @@ spec:
         volumeMounts:
         - name: config
           mountPath: "/etc/dragonfly"
+        {{- if ne (lower .Values.grpcAuth.mode) "disabled" }}
+        - name: grpc-auth
+          mountPath: {{ .Values.grpcAuth.mountPath | quote }}
+          readOnly: true
+        {{- end }}
         - name: storage
           mountPath: {{ .Values.seedClient.config.storage.dir }}
         {{- if .Values.seedClient.extraVolumeMounts }}
@@ -185,6 +190,17 @@ spec:
       - name: config
         configMap:
           name: {{ template "dragonfly.seedClient.fullname" . }}
+      {{- if ne (lower .Values.grpcAuth.mode) "disabled" }}
+      - name: grpc-auth
+        secret:
+          secretName: {{ required "grpcAuth.existingSecret is required when gRPC authentication is enabled" .Values.grpcAuth.existingSecret | quote }}
+          defaultMode: 0400
+          items:
+          {{- range $index, $key := .Values.grpcAuth.keys }}
+          - key: {{ $key.secretKey | quote }}
+            path: key-{{ $index }}
+          {{- end }}
+      {{- end }}
       {{- if not (.Values.seedClient.persistence.enable) }}
       - name: storage
         emptyDir: {}

--- a/charts/dragonfly/tests/grpc-auth-render.sh
+++ b/charts/dragonfly/tests/grpc-auth-render.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+chart_dir="${repo_root}/charts/dragonfly"
+test_dir="$(mktemp -d)"
+trap 'rm -rf "${test_dir}"' EXIT
+
+assert_count() {
+  local expected="$1"
+  local pattern="$2"
+  local rendered_file="$3"
+  local actual
+
+  actual="$(grep -Ec "${pattern}" "${rendered_file}" || true)"
+  if [[ "${actual}" -ne "${expected}" ]]; then
+    echo "expected ${expected} matches for ${pattern}, found ${actual}" >&2
+    exit 1
+  fi
+}
+
+helm template grpc-auth "${chart_dir}" >"${test_dir}/disabled.yaml"
+assert_count 0 '^[[:space:]]+grpcAuth:$' "${test_dir}/disabled.yaml"
+assert_count 0 'name: grpc-auth$' "${test_dir}/disabled.yaml"
+
+for mode in permissive required; do
+  helm template grpc-auth "${chart_dir}" \
+    --set manager.enable=true \
+    --set "grpcAuth.mode=${mode}" \
+    --set grpcAuth.existingSecret=dragonfly-grpc-auth \
+    >"${test_dir}/${mode}.yaml"
+
+  assert_count 4 '^[[:space:]]+grpcAuth:$' "${test_dir}/${mode}.yaml"
+  assert_count 4 "^[[:space:]]+mode: \"${mode}\"$" "${test_dir}/${mode}.yaml"
+  assert_count 8 'name: grpc-auth$' "${test_dir}/${mode}.yaml"
+  assert_count 4 'secretName: "dragonfly-grpc-auth"$' "${test_dir}/${mode}.yaml"
+done
+
+if helm template grpc-auth "${chart_dir}" \
+  --set grpcAuth.mode=permissive \
+  >"${test_dir}/missing-secret.log" 2>&1; then
+  echo "expected permissive mode without existingSecret to fail" >&2
+  exit 1
+fi
+grep -q 'grpcAuth.existingSecret is required' "${test_dir}/missing-secret.log"
+
+if helm template grpc-auth "${chart_dir}" \
+  --set grpcAuth.mode=invalid \
+  >"${test_dir}/invalid-mode.log" 2>&1; then
+  echo "expected an invalid authentication mode to fail" >&2
+  exit 1
+fi
+grep -q 'grpcAuth.mode must be one of disabled, permissive, or required' "${test_dir}/invalid-mode.log"

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -61,6 +61,39 @@ readinessProbe:
   # -- Failure threshold before the container is marked as not ready. Total time before marked not ready = initialDelaySeconds + (periodSeconds * failureThreshold).
   failureThreshold: 2
 
+# -- Shared JWT authentication for inter-component gRPC calls. Disabled mode
+# preserves the legacy behavior and renders no auth configuration or Secret
+# mounts. For the first authenticated rollout, use permissive before required.
+# The chart never creates or stores the key: create one Kubernetes Secret and
+# reference it here.
+grpcAuth:
+  # -- Authentication mode: disabled, permissive, or required. Permissive sends
+  # JWTs but accepts callers without one so old and new Pods can coexist during
+  # the first authenticated rolling upgrade.
+  mode: disabled
+  # -- Name of an existing Secret in the release namespace. Required when mode is not disabled.
+  existingSecret: ''
+  # -- ID of the key used to sign new JWTs.
+  activeKeyID: default
+  # -- Trusted keys stored as data entries in existingSecret. Keep old and new entries during rotation.
+  keys:
+    - id: default
+      secretKey: secret
+  # -- Directory used to mount the shared key read-only.
+  mountPath: /etc/dragonfly/grpc-auth
+  # -- JWT issuer shared by all Dragonfly components.
+  issuer: dragonfly-internal
+  # -- Lifetime of newly issued component JWTs.
+  tokenTTL: 10m
+  # -- Maximum accepted JWT lifetime.
+  maxTokenTTL: 15m
+  # -- Allowed clock skew when validating JWT timestamps.
+  clockSkew: 30s
+  # -- Regenerate a cached token this long before expiration.
+  refreshBefore: 1m
+  # -- Refuse to send JWTs over plaintext gRPC transports.
+  requireTransportSecurity: false
+
 manager:
   # -- Enable manager.
   enable: false


### PR DESCRIPTION

## Description

Add Helm deployment support for shared JWT authentication between Dragonfly components.

This change:

- Adds a global `grpcAuth` configuration for Manager, Scheduler, Client, and Seed Client.
- Supports `disabled`, `permissive`, and `required` authentication modes.
- Mounts a user-provided Kubernetes Secret as a read-only shared JWT keyring.
- Supports multiple trusted keys and `activeKeyID` for key rotation.
- Configures JWT issuer, token lifetime, maximum lifetime, clock skew, and refresh time.
- Validates authentication modes, Secret references, key IDs, duplicate keys, and active keys.
- Documents key generation, rolling upgrades, enforcement, rollback, and key rotation.
- Adds automated Helm rendering tests for the supported authentication modes.

Authentication is disabled by default. When `grpcAuth.mode` is omitted or set to `disabled`, the chart does not render authentication configuration, require a Secret, or add Secret volumes and mounts.

The chart does not store key material in values or ConfigMaps. It only references and mounts an existing Kubernetes Secret.

## Related Issue

Related to https://github.com/dragonflyoss/dragonfly/issues/4417

## Motivation and Context

JWT authentication requires the same trusted keyring and compatible configuration to be distributed to all Dragonfly components.

This change provides a simple global deployment workflow without requiring users to configure each component independently.

Users who do not enable JWT authentication can continue performing normal chart and application upgrades without changing existing behavior.

For the first authenticated rollout, users set the global mode to `permissive` while upgrading to JWT-capable application images. Upgraded callers send JWTs, upgraded servers accept requests with or without credentials, and older servers ignore the additional gRPC metadata. This allows old and new Pods to coexist during the rolling update.

After every component and maintained external caller sends JWTs, users change the global mode to `required`. The transition is rolling-upgrade safe because callers in both `permissive` and `required` modes send JWTs.

Once a deployment reaches `required` mode, later compatible application upgrades can use the normal one-step rolling upgrade while keeping authentication enabled.

This configuration is independent of the existing TLS and mTLS configuration. Users may enable either mechanism independently or use them together.
