### PR TITLE
Add writebackMode feature for dfdaemon

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,8 +3,8 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.7.8
-appVersion: 2.5.1
+version: 1.7.9
+appVersion: 2.5.2
 keywords:
   - dragonfly
   - d7y
@@ -27,9 +27,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Add optional privileged sysctl init container for client and seed client.
-    - Declare client and seed client affinity values.
-    - Fix client daemonset annotations misspelled as statefulset annotations.
+    - Add writebackMode option for dfdaemon.
   artifacthub.io/links: |
     - name: Chart Source
       url: https://github.com/dragonflyoss/helm-charts
@@ -39,15 +37,15 @@ annotations:
       url: https://github.com/dragonflyoss/client
   artifacthub.io/images: |
     - name: manager
-      image: dragonflyoss/manager:2.5.1
+      image: dragonflyoss/manager:v2.5.2-rc.0
     - name: scheduler
-      image: dragonflyoss/scheduler:v2.5.1
+      image: dragonflyoss/scheduler:v2.5.2-rc.0
     - name: client
-      image: dragonflyoss/client:v1.4.7
+      image: dragonflyoss/client:v1.5.2
     - name: seed-client
-      image: dragonflyoss/client:v1.4.7
+      image: dragonflyoss/client:v1.5.2
     - name: dfinit
-      image: dragonflyoss/dfinit:v1.4.7
+      image: dragonflyoss/dfinit:v1.5.2
     - name: injector
       image: dragonflyoss/injector:v0.1.0
 

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -188,6 +188,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.config.storage.server.tcpPort | int | `4005` | port is the port to the tcp server. |
 | client.config.storage.writeBufferSize | int | `524288` | writeBufferSize is the buffer size for writing piece to disk, default is 512KiB. |
 | client.config.storage.writePieceTimeout | string | `"360s"` | writePieceTimeout is the timeout for writing a piece to storage(e.g., disk or cache). |
+| client.config.storage.writebackMode | string | `"async"` | writebackMode is the mode of initiating writeback of written piece ranges to disk. sync awaits sync_file_range per piece write, async enqueues ranges to a dedicated background task and off leaves writeback to the kernel, default is async. |
 | client.config.tracing.protocol | string | `""` | Protocol specifies the communication protocol for the tracing server. Supported values: "http", "https", "grpc" (default: None). This determines how tracing logs are transmitted to the server. |
 | client.config.upload.bandwidthLimit | string | `"50GB"` | bandwidthLimit is the default rate limit of the upload speed in GB/Mb/Kb per second, default is 50GB/s. |
 | client.config.upload.disableShared | bool | `false` | disableShared indicates whether disable to share data with other peers. |
@@ -206,7 +207,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.dfinit.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | client.dfinit.image.registry | string | `"docker.io"` | Image registry. |
 | client.dfinit.image.repository | string | `"dragonflyoss/dfinit"` | Image repository. |
-| client.dfinit.image.tag | string | `"v1.4.7"` | Image tag. |
+| client.dfinit.image.tag | string | `"v1.5.2"` | Image tag. |
 | client.dfinit.restartContainerRuntime | bool | `true` | restartContainerRuntime indicates whether to restart container runtime when dfinit is enabled. it should be set to true when your first install dragonfly. If non-hot load configuration changes are made, the container runtime needs to be restarted. |
 | client.dynconfig | object | `{"clientConfig":{},"scheduler":{"addr":"","addrs":[]},"seedClientConfig":{}}` | dynconfig is the local dynamic configuration (dynconfig.yaml) for the client, delivered as a ConfigMap and mounted into the same directory as dfdaemon.yaml. It is only used when no manager is available (manager.enable is false and externalManager.host is empty), and it is refreshed periodically according to client.config.dynconfig.refreshInterval. |
 | client.dynconfig.clientConfig | object | `{}` | clientConfig is the block list configuration for clients running as normal peers, e.g. clientConfig: { blockList: { task: { download: { applications: [], urls: [], tags: [], priorities: [] } } } }. |
@@ -227,7 +228,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | client.image.registry | string | `"docker.io"` | Image registry. |
 | client.image.repository | string | `"dragonflyoss/client"` | Image repository. |
-| client.image.tag | string | `"v1.4.7"` | Image tag. |
+| client.image.tag | string | `"v1.5.2"` | Image tag. |
 | client.initContainer.image.digest | string | `""` | Image digest. |
 | client.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | client.initContainer.image.registry | string | `"docker.io"` | Image registry. |
@@ -306,13 +307,13 @@ helm delete dragonfly --namespace dragonfly-system
 | injector.image.registry | string | `"docker.io"` | Image registry. |
 | injector.image.repository | string | `"dragonflyoss/injector"` | Image repository. |
 | injector.image.tag | string | `"v0.1.0"` | Image tag. |
-| injector.initContainerImage | object | `{"digest":"","pullPolicy":"IfNotPresent","pullSecrets":[],"registry":"docker.io","repository":"dragonflyoss/client","tag":"v1.4.7"}` | initContainerImage is the image configuration for the init container that will be injected into target pods. |
+| injector.initContainerImage | object | `{"digest":"","pullPolicy":"IfNotPresent","pullSecrets":[],"registry":"docker.io","repository":"dragonflyoss/client","tag":"v1.5.2"}` | initContainerImage is the image configuration for the init container that will be injected into target pods. |
 | injector.initContainerImage.digest | string | `""` | Image digest. |
 | injector.initContainerImage.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | injector.initContainerImage.pullSecrets | list | `[]` | Image pull secrets. |
 | injector.initContainerImage.registry | string | `"docker.io"` | Image registry. |
 | injector.initContainerImage.repository | string | `"dragonflyoss/client"` | Image repository. |
-| injector.initContainerImage.tag | string | `"v1.4.7"` | Image tag. Should align with the version of Dragonfly client and seed client. |
+| injector.initContainerImage.tag | string | `"v1.5.2"` | Image tag. Should align with the version of Dragonfly client and seed client. |
 | injector.metrics.enable | bool | `false` | Enable injector metrics. |
 | injector.metrics.service.port | int | `8443` | Metrics service port. |
 | injector.nodeSelector | object | `{}` | Node labels for pod assignment. |
@@ -378,7 +379,7 @@ helm delete dragonfly --namespace dragonfly-system
 | manager.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | manager.image.registry | string | `"docker.io"` | Image registry. |
 | manager.image.repository | string | `"dragonflyoss/manager"` | Image repository. |
-| manager.image.tag | string | `"v2.5.1"` | Image tag. |
+| manager.image.tag | string | `"v2.5.2-rc.0"` | Image tag. |
 | manager.ingress.annotations | object | `{}` | Ingress annotations. |
 | manager.ingress.className | string | `""` | Ingress class name. Requirement: kubernetes >=1.18. |
 | manager.ingress.enable | bool | `false` | Enable ingress. |
@@ -500,7 +501,7 @@ helm delete dragonfly --namespace dragonfly-system
 | scheduler.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | scheduler.image.registry | string | `"docker.io"` | Image registry. |
 | scheduler.image.repository | string | `"dragonflyoss/scheduler"` | Image repository. |
-| scheduler.image.tag | string | `"v2.5.1"` | Image tag. |
+| scheduler.image.tag | string | `"v2.5.2-rc.0"` | Image tag. |
 | scheduler.initContainer.image.digest | string | `""` | Image digest. |
 | scheduler.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | scheduler.initContainer.image.registry | string | `"docker.io"` | Image registry. |
@@ -599,6 +600,7 @@ helm delete dragonfly --namespace dragonfly-system
 | seedClient.config.storage.server.tcpPort | int | `4005` | port is the port to the tcp server. |
 | seedClient.config.storage.writeBufferSize | int | `524288` | writeBufferSize is the buffer size for writing piece to disk, default is 512KiB. |
 | seedClient.config.storage.writePieceTimeout | string | `"360s"` | writePieceTimeout is the timeout for writing a piece to storage(e.g., disk or cache). |
+| seedClient.config.storage.writebackMode | string | `"async"` | writebackMode is the mode of initiating writeback of written piece ranges to disk. sync awaits sync_file_range per piece write, async enqueues ranges to a dedicated background task and off leaves writeback to the kernel, default is async. |
 | seedClient.config.tracing.protocol | string | `""` | Protocol specifies the communication protocol for the tracing server. Supported values: "http", "https", "grpc" (default: None). This determines how tracing logs are transmitted to the server. |
 | seedClient.config.upload.bandwidthLimit | string | `"50GB"` | bandwidthLimit is the default rate limit of the upload speed in GB/Mb/Kb per second, default is 50GB/s. |
 | seedClient.config.upload.server.port | int | `4000` | port is the port to the grpc server. |
@@ -621,7 +623,7 @@ helm delete dragonfly --namespace dragonfly-system
 | seedClient.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | seedClient.image.registry | string | `"docker.io"` | Image registry. |
 | seedClient.image.repository | string | `"dragonflyoss/client"` | Image repository. |
-| seedClient.image.tag | string | `"v1.4.7"` | Image tag. |
+| seedClient.image.tag | string | `"v1.5.2"` | Image tag. |
 | seedClient.initContainer.image.digest | string | `""` | Image digest. |
 | seedClient.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | seedClient.initContainer.image.registry | string | `"docker.io"` | Image registry. |

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -81,7 +81,7 @@ manager:
     # -- Image repository.
     repository: dragonflyoss/manager
     # -- Image tag.
-    tag: v2.5.1
+    tag: v2.5.2-rc.0
     # -- Image digest.
     digest: ''
     # -- Image pull policy.
@@ -377,7 +377,7 @@ scheduler:
     # -- Image repository.
     repository: dragonflyoss/scheduler
     # -- Image tag.
-    tag: v2.5.1
+    tag: v2.5.2-rc.0
     # -- Image digest.
     digest: ''
     # -- Image pull policy.
@@ -780,7 +780,7 @@ seedClient:
     # -- Image repository.
     repository: dragonflyoss/client
     # -- Image tag.
-    tag: v1.4.7
+    tag: v1.5.2
     # -- Image digest.
     digest: ''
     # -- Image pull policy.
@@ -1076,6 +1076,10 @@ seedClient:
       readBufferSize: 524288
       # -- writePieceTimeout is the timeout for writing a piece to storage(e.g., disk or cache).
       writePieceTimeout: 360s
+      # -- writebackMode is the mode of initiating writeback of written piece ranges to disk.
+      # sync awaits sync_file_range per piece write, async enqueues ranges to a dedicated
+      # background task and off leaves writeback to the kernel, default is async.
+      writebackMode: async
     gc:
       # -- interval is the interval to do gc.
       interval: 900s
@@ -1348,7 +1352,7 @@ client:
     # -- Image repository.
     repository: dragonflyoss/client
     # -- Image tag.
-    tag: v1.4.7
+    tag: v1.5.2
     # -- Image digest.
     digest: ''
     # -- Image pull policy.
@@ -1449,7 +1453,7 @@ client:
       # -- Image repository.
       repository: dragonflyoss/dfinit
       # -- Image tag.
-      tag: v1.4.7
+      tag: v1.5.2
       # -- Image digest.
       digest: ''
       # -- Image pull policy.
@@ -1712,6 +1716,10 @@ client:
       readBufferSize: 524288
       # -- writePieceTimeout is the timeout for writing a piece to storage(e.g., disk or cache).
       writePieceTimeout: 360s
+      # -- writebackMode is the mode of initiating writeback of written piece ranges to disk.
+      # sync awaits sync_file_range per piece write, async enqueues ranges to a dedicated
+      # background task and off leaves writeback to the kernel, default is async.
+      writebackMode: async
     gc:
       # -- interval is the interval to do gc.
       interval: 900s
@@ -2121,7 +2129,7 @@ injector:
     # -- Image repository.
     repository: dragonflyoss/client
     # -- Image tag. Should align with the version of Dragonfly client and seed client.
-    tag: v1.4.7
+    tag: v1.5.2
     # -- Image digest.
     digest: ''
     # -- Image pull policy.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces a new configurable option, `writebackMode`, for controlling how written data is flushed to disk in Dragonfly's storage components. It also updates the default container image versions across the chart to the latest releases, ensuring compatibility and access to new features and bug fixes.

**Key changes:**

**New Feature: Writeback Mode Configuration**
- Added the `writebackMode` option to the storage configuration for `client`, `seedClient`, and internal components, allowing users to choose between `sync`, `async`, or `off` modes for writeback operations. The default is `async`. This is documented in both `README.md` and `values.yaml` for all relevant subcharts. [[1]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR191) [[2]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR603) [[3]](diffhunk://#diff-148e0456558bafce1cfef542562969368319e78cd9a02822f3f4303fbf8b2f39R165) [[4]](diffhunk://#diff-148e0456558bafce1cfef542562969368319e78cd9a02822f3f4303fbf8b2f39R472) [[5]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bR1079-R1082) [[6]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bR1719-R1722) [[7]](diffhunk://#diff-c271a87e3e424ff18c8976fb00b2f6cf43ffde728cf9d9fefbee296ee4c1165bR858-R861) [[8]](diffhunk://#diff-c271a87e3e424ff18c8976fb00b2f6cf43ffde728cf9d9fefbee296ee4c1165bR1211-R1214)

**Image Version Updates**
- Updated the default image tags for all major Dragonfly components (manager, scheduler, client, seed-client, dfinit, injector) to the latest versions (`v2.5.2-rc.0`, `v1.5.2`, etc.) in both `Chart.yaml` and `values.yaml`, and reflected these changes in the documentation. [[1]](diffhunk://#diff-4f1af1c75d649da63a213e6ee988180b73ee3e14278748908bb056e9cd29c883L42-R48) [[2]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL209-R210) [[3]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL230-R231) [[4]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL309-R316) [[5]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL381-R382) [[6]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL503-R504) [[7]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL624-R626) [[8]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL84-R84) [[9]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL380-R380) [[10]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL783-R783) [[11]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL1351-R1355) [[12]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL1452-R1456) [[13]](diffhunk://#diff-e11a1bce6de1a9204ff3555f83b37165f2b1694c9d2073422a40daf6f8e9d63bL2124-R2132)

**Documentation Updates**
- Updated `README.md` for both the main and stack charts to document the new `writebackMode` option and reflect the new default image versions. [[1]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR191) [[2]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bR603) [[3]](diffhunk://#diff-148e0456558bafce1cfef542562969368319e78cd9a02822f3f4303fbf8b2f39R165) [[4]](diffhunk://#diff-148e0456558bafce1cfef542562969368319e78cd9a02822f3f4303fbf8b2f39R472) [[5]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL209-R210) [[6]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL230-R231) [[7]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL309-R316) [[8]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL381-R382) [[9]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL503-R504) [[10]](diffhunk://#diff-ab3616a93a116bdedaf154d37cf22079e8e253578cc200f07d262cb7cda2783bL624-R626)

**Chart Version Bump**
- Incremented the chart version to `1.7.9` and app version to `2.5.2` to reflect these changes.

**Changelog Entry**
- Updated the chart changelog annotation to mention the addition of the `writebackMode` option for `dfdaemon`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
