### PR TITLE
feat: add criPluginId field to support the cri plugin in dfinit

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.8.0
+version: 1.8.1
 appVersion: 2.5.2
 keywords:
   - dragonfly
@@ -27,10 +27,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Add PostgreSQL support for manager database.
-    - Add optional privileged sysctl init container for client and seed client.
-    - Declare client and seed client affinity values.
-    - Fix client daemonset annotations misspelled as statefulset annotations.
+    - Add criPluginId field to support the cri plugin in dfinit.
   artifacthub.io/links: |
     - name: Chart Source
       url: https://github.com/dragonflyoss/helm-charts

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -1471,6 +1471,12 @@ client:
         containerd:
           # -- configPath is the path of containerd configuration file.
           configPath: /etc/containerd/config.toml
+          # # -- criPluginId is the CRI plugin id owning the registry configuration, e.g. "io.containerd.grpc.v1.cri"
+          # # or "io.containerd.cri.v1.images". If not set, the plugin table present in the containerd
+          # # configuration is used, preferring "io.containerd.grpc.v1.cri" for version 2 configurations
+          # # and "io.containerd.cri.v1.images" for version 3.
+          # criPluginId: io.containerd.cri.v1.images
+          #
           # -- Proxy all registries enables a catch-all `_default/hosts.toml` entry so that any
           # registry not explicitly listed in `registries` is still proxied through dfdaemon.
           # The dfdaemon infers the upstream registry from the `ns=` query parameter that


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the Dragonfly Helm chart with a new feature and a version bump. The main change is the addition of a configurable `criPluginId` field for containerd CRI plugin support in the client, which is now documented in the chart's values and changelog.

Helm chart version update:

* Bumped the chart version from `1.8.0` to `1.8.1` in `Chart.yaml` to reflect the new feature.

New feature: CRI plugin support

* Added a `criPluginId` field under `client.containerd` in `values.yaml`, allowing users to specify the CRI plugin ID for registry configuration. This provides better compatibility with different containerd configurations.
* Updated the changelog in `Chart.yaml` to document the new `criPluginId` field for dfinit's CRI plugin support.
<!--- Describe your changes in detail -->

## Related Issue

https://github.com/dragonflyoss/client/pull/2004
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
