### PR TITLE
Update client version to 1.5.4

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,7 +3,7 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/dragonfly/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.8.3
+version: 1.8.4
 appVersion: 2.5.2
 keywords:
   - dragonfly
@@ -27,7 +27,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
-    - Add backToSourceConcurrentPieceCount option for dfdaemon.
+    - Bump Dragonfly Client to v1.5.4.
   artifacthub.io/links: |
     - name: Chart Source
       url: https://github.com/dragonflyoss/helm-charts
@@ -41,9 +41,9 @@ annotations:
     - name: scheduler
       image: dragonflyoss/scheduler:v2.5.2-rc.0
     - name: client
-      image: dragonflyoss/client:v1.5.2
+      image: dragonflyoss/client:v1.5.4
     - name: seed-client
-      image: dragonflyoss/client:v1.5.2
+      image: dragonflyoss/client:v1.5.4
     - name: dfinit
       image: dragonflyoss/dfinit:v1.5.2
     - name: injector

--- a/charts/dragonfly/README.md
+++ b/charts/dragonfly/README.md
@@ -229,7 +229,7 @@ helm delete dragonfly --namespace dragonfly-system
 | client.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | client.image.registry | string | `"docker.io"` | Image registry. |
 | client.image.repository | string | `"dragonflyoss/client"` | Image repository. |
-| client.image.tag | string | `"v1.5.2"` | Image tag. |
+| client.image.tag | string | `"v1.5.4"` | Image tag. |
 | client.initContainer.image.digest | string | `""` | Image digest. |
 | client.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | client.initContainer.image.registry | string | `"docker.io"` | Image registry. |
@@ -317,13 +317,13 @@ helm delete dragonfly --namespace dragonfly-system
 | injector.image.registry | string | `"docker.io"` | Image registry. |
 | injector.image.repository | string | `"dragonflyoss/injector"` | Image repository. |
 | injector.image.tag | string | `"v0.1.0"` | Image tag. |
-| injector.initContainerImage | object | `{"digest":"","pullPolicy":"IfNotPresent","pullSecrets":[],"registry":"docker.io","repository":"dragonflyoss/client","tag":"v1.5.2"}` | initContainerImage is the image configuration for the init container that will be injected into target pods. |
+| injector.initContainerImage | object | `{"digest":"","pullPolicy":"IfNotPresent","pullSecrets":[],"registry":"docker.io","repository":"dragonflyoss/client","tag":"v1.5.4"}` | initContainerImage is the image configuration for the init container that will be injected into target pods. |
 | injector.initContainerImage.digest | string | `""` | Image digest. |
 | injector.initContainerImage.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | injector.initContainerImage.pullSecrets | list | `[]` | Image pull secrets. |
 | injector.initContainerImage.registry | string | `"docker.io"` | Image registry. |
 | injector.initContainerImage.repository | string | `"dragonflyoss/client"` | Image repository. |
-| injector.initContainerImage.tag | string | `"v1.5.2"` | Image tag. Should align with the version of Dragonfly client and seed client. |
+| injector.initContainerImage.tag | string | `"v1.5.4"` | Image tag. Should align with the version of Dragonfly client and seed client. |
 | injector.metrics.enable | bool | `false` | Enable injector metrics. |
 | injector.metrics.service.port | int | `8443` | Metrics service port. |
 | injector.nodeSelector | object | `{}` | Node labels for pod assignment. |
@@ -634,7 +634,7 @@ helm delete dragonfly --namespace dragonfly-system
 | seedClient.image.pullSecrets | list | `[]` (defaults to global.imagePullSecrets). | Image pull secrets. |
 | seedClient.image.registry | string | `"docker.io"` | Image registry. |
 | seedClient.image.repository | string | `"dragonflyoss/client"` | Image repository. |
-| seedClient.image.tag | string | `"v1.5.2"` | Image tag. |
+| seedClient.image.tag | string | `"v1.5.4"` | Image tag. |
 | seedClient.initContainer.image.digest | string | `""` | Image digest. |
 | seedClient.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | seedClient.initContainer.image.registry | string | `"docker.io"` | Image registry. |

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -780,7 +780,7 @@ seedClient:
     # -- Image repository.
     repository: dragonflyoss/client
     # -- Image tag.
-    tag: v1.5.2
+    tag: v1.5.4
     # -- Image digest.
     digest: ''
     # -- Image pull policy.
@@ -1374,7 +1374,7 @@ client:
     # -- Image repository.
     repository: dragonflyoss/client
     # -- Image tag.
-    tag: v1.5.2
+    tag: v1.5.4
     # -- Image digest.
     digest: ''
     # -- Image pull policy.
@@ -2199,7 +2199,7 @@ injector:
     # -- Image repository.
     repository: dragonflyoss/client
     # -- Image tag. Should align with the version of Dragonfly client and seed client.
-    tag: v1.5.2
+    tag: v1.5.4
     # -- Image digest.
     digest: ''
     # -- Image pull policy.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Bump the Dragonfly client image from v1.5.2 to v1.5.4 in the dragonfly chart.

This updates dragonflyoss/client for the client, seed client, and injector init container, regenerates the chart README with helm-docs, and increments the chart version from 1.8.3 to 1.8.4. 

dfinit remains at v1.5.2 -> please advise if this should also be updated

## Related Issue

https://github.com/dragonflyoss/client/issues/2016

-> this issue was resolved in release v1.5.4

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
